### PR TITLE
Add Initial Support for Msearch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,5 @@ jobs:
         run: cargo run --example simple_aggs
       - name: 'Example: filter_aggs'
         run: cargo run --example filter_aggs
+      - name: 'Example: multi_search'
+        run: cargo run --example multi_search

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ path = "examples/simple_aggs.rs"
 name = "filter_aggs"
 path = "examples/filter_aggs.rs"
 
+[[example]]
+name = "multi_search"
+path = "examples/multi_search.rs"
+
 # To avoid repeating the same model over and
 # over between examples this serves as a shared
 # lib for them

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ real work project.  This is what is driving it's development
 for now; however, if you have suggestions or edits please feel
 free to open an issue :+1:.
 
-## Funtionality Tour
+## Functionality Tour
 
 All of these samples can also be found in `examples/sample_code.rs`.
 
@@ -88,6 +88,41 @@ pub async fn complex_search() -> Result<SearchResults<Value>, Error> {
     });
 
     Ok(client.search(&search).await?)
+}
+```
+
+### MultiSearch
+
+```rust
+use super::inventory_item::InventoryItem;
+use elastic_lens::{prelude::*, Error};
+
+pub async fn report_clothing_and_office() -> Result<(), Error> {
+    let client = create_client()?;
+
+    let mut clothing = Search::default();
+    clothing.field("category").contains("clothing");
+
+    let mut office = Search::default();
+    office.field("category").contains("office");
+
+    let results = client
+        .multi_search::<InventoryItem>(&[clothing, office])
+        .await?;
+
+    println!("Clothing:");
+
+    for doc in results[0].docs() {
+        println!("{doc:?}");
+    }
+
+    println!("\nOffice:");
+
+    for doc in results[1].docs() {
+        println!("{doc:?}");
+    }
+
+    Ok(())
 }
 ```
 

--- a/examples/multi_search.rs
+++ b/examples/multi_search.rs
@@ -1,0 +1,36 @@
+mod inventory_item;
+use elastic_lens::prelude::*;
+use elastic_lens::Error;
+use inventory_item::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let client = Client::default_builder()
+        .host("http://localhost:9200")
+        .index("inventory")
+        .build()?;
+
+    let mut clothing = Search::default();
+    clothing.field("category").contains("clothing");
+
+    let mut office = Search::default();
+    office.field("category").contains("office");
+
+    let results = client
+        .multi_search::<InventoryItem>(&[clothing, office])
+        .await?;
+
+    println!("Clothing:");
+
+    for doc in results[0].docs() {
+        println!("{doc:?}");
+    }
+
+    println!("\nOffice:");
+
+    for doc in results[1].docs() {
+        println!("{doc:?}");
+    }
+
+    Ok(())
+}

--- a/examples/sample_code.rs
+++ b/examples/sample_code.rs
@@ -140,3 +140,37 @@ pub mod filter_aggregation {
         Ok(results.aggs_mut().take::<Filtered>("under-twenty")?)
     }
 }
+
+pub mod multi_search {
+    use super::inventory_item::InventoryItem;
+    use crate::create_client::create_client;
+    use elastic_lens::{prelude::*, Error};
+
+    pub async fn report_clothing_and_office() -> Result<(), Error> {
+        let client = create_client()?;
+
+        let mut clothing = Search::default();
+        clothing.field("category").contains("clothing");
+
+        let mut office = Search::default();
+        office.field("category").contains("office");
+
+        let results = client
+            .multi_search::<InventoryItem>(&[clothing, office])
+            .await?;
+
+        println!("Clothing:");
+
+        for doc in results[0].docs() {
+            println!("{doc:?}");
+        }
+
+        println!("\nOffice:");
+
+        for doc in results[1].docs() {
+            println!("{doc:?}");
+        }
+
+        Ok(())
+    }
+}

--- a/src/client/adapter.rs
+++ b/src/client/adapter.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::request::MultiSearch;
 use serde::Serialize;
 
 /// Every error that can be emmited by an adapter
@@ -34,10 +35,14 @@ pub trait ClientAdapter: private::SealedClientAdapter {
     /// Given a body that can serialize execute a search
     /// against the configured index and possible doc type
     async fn search<B: Serialize + Sync>(&self, body: &B) -> Result<String, AdapterError>;
+
+    /// Performs multiple searches at once
+    async fn multi_search<'a>(&self, mut searches: MultiSearch<'a>)
+        -> Result<String, AdapterError>;
 }
 
 mod private {
-    use crate::client::offical_client_adapter::ElasticsearchAdapter;
+    use crate::client::offical_adapter::ElasticsearchAdapter;
 
     pub trait SealedClientAdapter: Send + Sync + Sized {}
 

--- a/src/client/offical_adapter/util.rs
+++ b/src/client/offical_adapter/util.rs
@@ -1,0 +1,41 @@
+use super::*;
+use crate::request::search::SearchBody;
+use serde::Serialize;
+
+/// An MSearch requires a "header" row above every request
+/// row that is sent.  Since we really don't have anything
+/// to send along for this row, this serves as a marketer
+/// to the serialize to that fact.
+pub(super) enum MsearchBody<'a> {
+    EmptyMeta,
+    Search(SearchBody<'a>),
+}
+
+impl<'a> Serialize for MsearchBody<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        match self {
+            Self::Search(body) => body.serialize(serializer),
+            Self::EmptyMeta => {
+                let map = serializer.serialize_map(Some(0))?;
+                map.end()
+            }
+        }
+    }
+}
+
+/// consumes the multisearch and extracts the search bodies
+/// over to a set of empty headers and bodies and then wrapped
+/// by `JsonBody` as that is the interface for the Elasticsearch
+/// client
+pub(super) fn multisearch_to_body(mut search: MultiSearch<'_>) -> Vec<JsonBody<MsearchBody<'_>>> {
+    search
+        .bodies
+        .drain(..)
+        .flat_map(|body| [MsearchBody::EmptyMeta, MsearchBody::Search(body)])
+        .map(JsonBody::new)
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,5 +37,6 @@ pub mod prelude {
     pub use crate::request::search::{
         AggregationBuilder, CriteriaBuilder, IntoGeoPoint, Search, SubAggregationBuilder,
     };
+    pub use crate::request::MultiSearch;
     pub use crate::response::{Filtered, NumericTerms, Stats, StringTerms};
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,3 +1,6 @@
 //! All of the logic surrounding creating a request is held in this module.
 
 pub mod search;
+
+mod multi_search;
+pub use multi_search::*;

--- a/src/request/multi_search.rs
+++ b/src/request/multi_search.rs
@@ -1,0 +1,50 @@
+//! Logic around creating and sending multiple search requests at once
+
+use super::search::{SearchBody, SearchTrait};
+
+/// MultiSearch
+///
+/// This allows for the sending of multiple searches
+/// inside of a single request to avoid IO round trips.
+/// In it's current form it works with multiple different
+/// `SearchTrait` at the same time as it's just holding
+/// a reference to it's search body.
+#[derive(Debug, Default)]
+pub struct MultiSearch<'a> {
+    pub(crate) bodies: Vec<SearchBody<'a>>,
+}
+
+/// This is an opaque type that is used
+/// to retreive the contents of the search
+/// for which it was returned when added to
+/// `MultiSearch`
+#[derive(Debug, Clone, Copy)]
+pub struct LookupKey(usize);
+
+impl<'a> MultiSearch<'a> {
+    /// If you know how many requests you want to send at
+    /// once this will help avoid excess allocations
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            bodies: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Adds a search
+    ///
+    /// This queues to search to be included and returns
+    /// a lookup key which will be needed to retreive the
+    /// results back from the multi-response.
+    pub fn add<T: SearchTrait>(&mut self, search: &'a T) -> LookupKey {
+        self.bodies.push(search.search_body());
+        LookupKey(self.bodies.len() - 1)
+    }
+}
+
+impl<'a, B: Into<SearchBody<'a>>, I: IntoIterator<Item = B>> From<I> for MultiSearch<'a> {
+    fn from(value: I) -> Self {
+        let bodies = value.into_iter().map(Into::into).collect();
+
+        Self { bodies }
+    }
+}

--- a/src/request/search/search_trait.rs
+++ b/src/request/search/search_trait.rs
@@ -6,7 +6,7 @@ use super::*;
 /// return whatever a naked search would.
 ///
 /// If you want to find an implementation look at `Search`.
-pub trait SearchTrait: Sized {
+pub trait SearchTrait {
     /// How many documents to limit by, None will use the default
     fn limit(&self) -> Option<usize> {
         None
@@ -35,7 +35,10 @@ pub trait SearchTrait: Sized {
     /// Produces a structure that can be serialized into the body
     /// request for Elasticsearch.  This is a borrow from the trait
     /// and therefore locks modification while the body is around.
-    fn search_body(&self) -> SearchBody<'_> {
+    fn search_body(&self) -> SearchBody<'_>
+    where
+        Self: Sized,
+    {
         SearchBody::from(self)
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,8 @@
 //! All of the logic for parsing and working with a response is in this module.
 
+mod multi_results;
 mod search_results;
 pub(crate) mod single_document;
 
+pub use multi_results::*;
 pub use search_results::*;

--- a/src/response/multi_results.rs
+++ b/src/response/multi_results.rs
@@ -1,0 +1,17 @@
+use super::*;
+use serde::Deserialize;
+use std::ops::Index;
+
+/// The multi-reponse payload for `multi_search`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MultiResponse<T: Clone + std::fmt::Debug> {
+    responses: Vec<SearchResults<T>>,
+}
+
+impl<T: Clone + std::fmt::Debug> Index<usize> for MultiResponse<T> {
+    type Output = SearchResults<T>;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.responses.index(index)
+    }
+}


### PR DESCRIPTION
This implements multi-search in the most ergonomic way that I would expect to see it done; which is being able to provide an iteratorable structure that will correctly serialize into the msearch request under the hood.

Something else I've done as a side feature is the structure responsible for converting these can actually work with different search types at the same time if the collection is made ahead of time.

I feel this is a good first pass; however, another feature addition pass is for sure in the works.  Items to solve in future work include:

- Handling of a search that fails in in isolation
- Adding more ergonomic features to the MultiSearch structure