### PR TITLE
Add Sort Functionality to ElasticLens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,5 @@ jobs:
         run: cargo run --example filter_aggs
       - name: 'Example: multi_search'
         run: cargo run --example multi_search
+      - name: 'Example: simple_sort'
+        run: cargo run --example simple_sort

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ path = "examples/filter_aggs.rs"
 name = "multi_search"
 path = "examples/multi_search.rs"
 
+[[example]]
+name = "simple_sort"
+path = "examples/simple_sort.rs"
+
 # To avoid repeating the same model over and
 # over between examples this serves as a shared
 # lib for them

--- a/README.md
+++ b/README.md
@@ -126,6 +126,50 @@ pub async fn report_clothing_and_office() -> Result<(), Error> {
 }
 ```
 
+### Simple Field Sort
+
+```rust
+use elastic_lens::{prelude::*, response::SearchResults, Error};
+use serde_json::Value;
+
+pub async fn five_cheapest_items() -> Result<SearchResults<Value>, Error> {
+    let client = create_client()?;
+    let mut search = Search::default();
+
+    search
+        .sort_field("cost")
+        .ascending()
+        .with_missing_values_last();
+
+    search.set_limit(5);
+
+    Ok(client.search(&search).await?)
+}
+```
+
+### Sorting by GeoDistance
+
+```rust
+use elastic_lens::{prelude::*, request::search::GeoPoint, response::SearchResults, Error};
+use serde_json::Value;
+
+pub async fn nearest_allies() -> Result<SearchResults<Value>, Error> {
+    let client = create_client()?;
+
+    let mut search = Search::default();
+
+    search.field("user.is_ally").contains(true);
+
+    search
+        .sort_field("user.location")
+        .by_distance_from(GeoPoint::new(1.1, 2.2))
+        .in_ascending_order()
+        .ignore_unmapped_documents();
+
+    Ok(client.search(&search).await?)
+}
+```
+
 ### Term Aggregations
 
 ```rust

--- a/examples/sample_code.rs
+++ b/examples/sample_code.rs
@@ -174,3 +174,45 @@ pub mod multi_search {
         Ok(())
     }
 }
+
+pub mod geo_sort {
+    use crate::create_client::create_client;
+    use elastic_lens::{prelude::*, request::search::GeoPoint, response::SearchResults, Error};
+    use serde_json::Value;
+
+    pub async fn nearest_allies() -> Result<SearchResults<Value>, Error> {
+        let client = create_client()?;
+
+        let mut search = Search::default();
+
+        search.field("user.is_ally").contains(true);
+
+        search
+            .sort_field("user.location")
+            .by_distance_from(GeoPoint::new(1.1, 2.2))
+            .in_ascending_order()
+            .ignore_unmapped_documents();
+
+        Ok(client.search(&search).await?)
+    }
+}
+
+pub mod five_cheapest {
+    use crate::create_client::create_client;
+    use elastic_lens::{prelude::*, response::SearchResults, Error};
+    use serde_json::Value;
+
+    pub async fn five_cheapest_items() -> Result<SearchResults<Value>, Error> {
+        let client = create_client()?;
+        let mut search = Search::default();
+
+        search
+            .sort_field("cost")
+            .ascending()
+            .with_missing_values_last();
+
+        search.set_limit(5);
+
+        Ok(client.search(&search).await?)
+    }
+}

--- a/examples/simple_sort.rs
+++ b/examples/simple_sort.rs
@@ -1,0 +1,25 @@
+mod inventory_item;
+
+use elastic_lens::prelude::*;
+use elastic_lens::Error;
+use inventory_item::InventoryItem;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let client = Client::default_builder()
+        .host("http://localhost:9200")
+        .index("inventory")
+        .build()?;
+
+    let mut search = Search::default();
+
+    search.sort_field("cost").ascending();
+
+    let results = client.search::<InventoryItem>(&search).await?;
+
+    for doc in results.docs() {
+        println!("{doc:?}");
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,8 @@ pub use errors::*;
 pub mod prelude {
     pub use crate::client::Client;
     pub use crate::request::search::{
-        AggregationBuilder, CriteriaBuilder, IntoGeoPoint, Search, SubAggregationBuilder,
+        AggregationBuilder, CriteriaBuilder, IntoGeoPoint, Search, SortBuilderTrait,
+        SubAggregationBuilder,
     };
     pub use crate::request::MultiSearch;
     pub use crate::response::{Filtered, NumericTerms, Stats, StringTerms};

--- a/src/request/search.rs
+++ b/src/request/search.rs
@@ -12,6 +12,7 @@ mod geo_values;
 mod numeric_value;
 mod scalar_value;
 mod search_trait;
+mod sort_directive;
 mod target;
 
 pub use aggregation::*;
@@ -22,6 +23,7 @@ pub use geo_values::*;
 pub use numeric_value::*;
 pub use scalar_value::*;
 pub use search_trait::*;
+pub use sort_directive::*;
 pub use target::*;
 
 /// Used to construct a search request for Elasticsearch
@@ -29,6 +31,7 @@ pub use target::*;
 pub struct Search {
     positive_criteria: Vec<Criterion>,
     negative_criteria: Vec<Criterion>,
+    sorts: Vec<SortDirective>,
     aggregations: Option<AggCollection>,
     limit: Option<usize>,
     offset: Option<usize>,
@@ -71,6 +74,14 @@ impl SearchTrait for Search {
         }
     }
 
+    fn sort_directives(&self) -> Option<&Vec<SortDirective>> {
+        if self.sorts.is_empty() {
+            None
+        } else {
+            Some(&self.sorts)
+        }
+    }
+
     fn aggregations(&self) -> Option<&AggCollection> {
         self.aggregations.as_ref()
     }
@@ -91,5 +102,11 @@ impl CriteriaBuilder for Search {
 impl AggregationBuilder for Search {
     fn aggregations_mut(&mut self) -> &mut AggCollection {
         self.aggregations.get_or_insert_with(AggCollection::default)
+    }
+}
+
+impl SortBuilderTrait for Search {
+    fn sort_directives_mut(&mut self) -> &mut Vec<SortDirective> {
+        &mut self.sorts
     }
 }

--- a/src/request/search/body.rs
+++ b/src/request/search/body.rs
@@ -16,6 +16,7 @@ impl<'a, S: SearchTrait> From<&'a S> for SearchBody<'a> {
                 },
             },
             aggs: value.aggregations(),
+            sort: value.sort_directives(),
         }
     }
 }
@@ -43,6 +44,9 @@ pub struct SearchBody<'a> {
 
     #[serde(skip_serializing_if = "SkipNode::not_needed")]
     aggs: Option<&'a AggCollection>,
+
+    #[serde(skip_serializing_if = "SkipNode::not_needed")]
+    sort: Option<&'a Vec<SortDirective>>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/request/search/geo_values.rs
+++ b/src/request/search/geo_values.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 /// Implement this trait in your codebase for your
 /// foreign types if you plan to use them directly
 /// for operations that require a `GeoPoint`.
-#[derive(Debug, Copy, Clone, PartialEq, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Default)]
 pub struct GeoPoint {
     /// The latitude is specified by degrees, starting from 0
     /// and ending up with 90° to both sides of the equator,

--- a/src/request/search/search_trait.rs
+++ b/src/request/search/search_trait.rs
@@ -32,6 +32,11 @@ pub trait SearchTrait {
         None
     }
 
+    /// any ways to sort a search
+    fn sort_directives(&self) -> Option<&Vec<SortDirective>> {
+        None
+    }
+
     /// Produces a structure that can be serialized into the body
     /// request for Elasticsearch.  This is a borrow from the trait
     /// and therefore locks modification while the body is around.

--- a/src/request/search/sort_directive.rs
+++ b/src/request/search/sort_directive.rs
@@ -1,0 +1,36 @@
+use super::*;
+use serde::Serialize;
+
+mod builder_trait;
+mod direction;
+mod field_params;
+mod geo_params;
+mod missing_value;
+
+pub use builder_trait::*;
+pub use direction::*;
+pub use field_params::*;
+pub use geo_params::*;
+pub use missing_value::*;
+
+/// Describes a way to sort documents from a search
+#[derive(Debug, Clone)]
+pub enum SortDirective {
+    /// Sort by Field
+    Field(SortField),
+
+    /// Sort from GeoPoint
+    GeoDistance(SortGeo),
+}
+
+impl Serialize for SortDirective {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Field(params) => params.serialize(serializer),
+            Self::GeoDistance(params) => params.serialize(serializer),
+        }
+    }
+}

--- a/src/request/search/sort_directive/builder_trait.rs
+++ b/src/request/search/sort_directive/builder_trait.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+mod field_sort_builder;
+mod field_sort_builder_options;
+mod geo_distance_sort_builder;
+
+pub use field_sort_builder::*;
+pub use field_sort_builder_options::*;
+pub use geo_distance_sort_builder::*;
+
+/// Trait used to provide self-sort construction
+pub trait SortBuilderTrait {
+    /// mutable reference to sorts you want to build on
+    fn sort_directives_mut(&mut self) -> &mut Vec<SortDirective>;
+
+    /// Target a field to sort
+    fn sort_field<F: Into<Field>>(&mut self, field: F) -> FieldSortBuilder<'_> {
+        FieldSortBuilder {
+            field: field.into(),
+            sorts: self.sort_directives_mut(),
+        }
+    }
+}
+
+impl SortBuilderTrait for Vec<SortDirective> {
+    fn sort_directives_mut(&mut self) -> &mut Vec<SortDirective> {
+        self
+    }
+}

--- a/src/request/search/sort_directive/builder_trait/field_sort_builder.rs
+++ b/src/request/search/sort_directive/builder_trait/field_sort_builder.rs
@@ -1,0 +1,46 @@
+use super::*;
+
+/// The first step towards building a sort where a document
+/// field is the target
+#[derive(Debug)]
+#[must_use = "A selection must be made to build a sort"]
+pub struct FieldSortBuilder<'a> {
+    pub(super) field: Field,
+    pub(super) sorts: &'a mut Vec<SortDirective>,
+}
+
+impl<'a> FieldSortBuilder<'a> {
+    /// Creates a geo-distance sort. There are a number of options
+    /// you can add to this sort, but when you end the chain it
+    /// will build with whatever options you take.
+    pub fn by_distance_from<P: IntoGeoPoint>(self, location: P) -> GeoDistanceSortBuilder<'a> {
+        GeoDistanceSortBuilder {
+            field: self.field,
+            location: location.into_geo_point(),
+            sorts: self.sorts,
+            order: None,
+            ignore_unmapped: None,
+            calc_formula: None,
+        }
+    }
+
+    /// sort field in decending order
+    pub fn descending(self) -> FieldSortBuilderOptions<'a> {
+        FieldSortBuilderOptions {
+            field: self.field,
+            sorts: self.sorts,
+            direction: SortDirection::Descending,
+            missing_value: None,
+        }
+    }
+
+    /// sort field in ascending order
+    pub fn ascending(self) -> FieldSortBuilderOptions<'a> {
+        FieldSortBuilderOptions {
+            field: self.field,
+            sorts: self.sorts,
+            direction: SortDirection::Ascending,
+            missing_value: None,
+        }
+    }
+}

--- a/src/request/search/sort_directive/builder_trait/field_sort_builder_options.rs
+++ b/src/request/search/sort_directive/builder_trait/field_sort_builder_options.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+/// Aids in finishing a field sort for a search
+#[derive(Debug)]
+pub struct FieldSortBuilderOptions<'a> {
+    pub(super) field: Field,
+    pub(super) sorts: &'a mut Vec<SortDirective>,
+    pub(super) direction: SortDirection,
+    pub(super) missing_value: Option<MissingValue>,
+}
+
+impl<'a> FieldSortBuilderOptions<'a> {
+    /// If the field is missing a value, use this in those cases
+    pub fn where_missing_use<V: Into<ScalarValue>>(mut self, value: V) {
+        self.missing_value = Some(MissingValue::Custom(value.into()));
+    }
+
+    /// Documents without a value are sorted last
+    pub fn with_missing_values_last(mut self) {
+        self.missing_value = Some(MissingValue::Last);
+    }
+
+    /// Documents without a value are sorted first
+    pub fn with_missing_values_first(mut self) {
+        self.missing_value = Some(MissingValue::First);
+    }
+}
+
+impl<'a> Drop for FieldSortBuilderOptions<'a> {
+    fn drop(&mut self) {
+        let mut field = "".into();
+        let mut direction = SortDirection::Ascending;
+        std::mem::swap(&mut field, &mut self.field);
+        std::mem::swap(&mut direction, &mut self.direction);
+
+        let sort = SortField {
+            field,
+            direction: Some(direction),
+            missing_value: self.missing_value.take(),
+        };
+
+        self.sorts.push(sort.into());
+    }
+}

--- a/src/request/search/sort_directive/builder_trait/geo_distance_sort_builder.rs
+++ b/src/request/search/sort_directive/builder_trait/geo_distance_sort_builder.rs
@@ -1,0 +1,68 @@
+use super::*;
+
+/// Aids in building a geo-distance sort for `FieldSortBuilder`
+#[derive(Debug)]
+pub struct GeoDistanceSortBuilder<'a> {
+    pub(super) field: Field,
+    pub(super) location: GeoPoint,
+    pub(super) sorts: &'a mut Vec<SortDirective>,
+    pub(super) order: Option<SortDirection>,
+    pub(super) ignore_unmapped: Option<bool>,
+    pub(super) calc_formula: Option<CalculationFormula>,
+}
+
+impl GeoDistanceSortBuilder<'_> {
+    /// Sort ascending
+    pub fn in_ascending_order(&mut self) -> &mut Self {
+        self.order = Some(SortDirection::Ascending);
+        self
+    }
+
+    /// Sort descending
+    pub fn in_descending_order(&mut self) -> &mut Self {
+        self.order = Some(SortDirection::Descending);
+        self
+    }
+
+    /// Arc is normally the default, and most accurate
+    pub fn using_the_arc_formula(&mut self) -> &mut Self {
+        self.calc_formula = Some(CalculationFormula::Arc);
+        self
+    }
+
+    /// Plane is less accurate, especially over longer
+    /// distances and near the poles; however, it is much
+    /// faster
+    pub fn using_the_plane_formula(&mut self) -> &mut Self {
+        self.calc_formula = Some(CalculationFormula::Plane);
+        self
+    }
+
+    /// By default Elasticsearch will error on a document
+    /// if it's missing the field being used; setting this
+    /// will instead allow the search to work and the documents
+    /// missing the distance will be considered "Infinity"
+    pub fn ignore_unmapped_documents(&mut self) -> &mut Self {
+        self.ignore_unmapped = Some(true);
+        self
+    }
+}
+
+impl Drop for GeoDistanceSortBuilder<'_> {
+    fn drop(&mut self) {
+        let mut field = "".into();
+        let mut location = GeoPoint::default();
+        std::mem::swap(&mut field, &mut self.field);
+        std::mem::swap(&mut location, &mut self.location);
+
+        let sort = SortGeo {
+            field,
+            location,
+            order: self.order.take(),
+            ignore_unmapped: self.ignore_unmapped.take(),
+            calc_formula: self.calc_formula.take(),
+        };
+
+        self.sorts.push(sort.into());
+    }
+}

--- a/src/request/search/sort_directive/direction.rs
+++ b/src/request/search/sort_directive/direction.rs
@@ -1,0 +1,22 @@
+use serde::Serialize;
+
+/// Direction to sort results
+#[derive(Debug, Copy, Clone)]
+pub enum SortDirection {
+    /// smallest to biggest
+    Ascending,
+    /// biggest to smallest
+    Descending,
+}
+
+impl Serialize for SortDirection {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Ascending => "asc".serialize(serializer),
+            Self::Descending => "desc".serialize(serializer),
+        }
+    }
+}

--- a/src/request/search/sort_directive/field_params.rs
+++ b/src/request/search/sort_directive/field_params.rs
@@ -1,0 +1,125 @@
+use super::*;
+use serde::Serialize;
+
+/// How to sort documents by field
+#[derive(Debug, Clone)]
+pub struct SortField {
+    pub(super) field: Field,
+    pub(super) direction: Option<SortDirection>,
+    pub(super) missing_value: Option<MissingValue>,
+}
+
+impl SortField {
+    /// Starts the construction of a new field sort by
+    /// providing a builder that can set optional parameters
+    /// before building
+    pub fn field<F: Into<Field>>(field: F) -> SortFieldBuilder {
+        SortFieldBuilder {
+            field: field.into(),
+            direction: None,
+            missing_value: None,
+        }
+    }
+}
+
+impl From<SortField> for SortDirective {
+    fn from(value: SortField) -> Self {
+        Self::Field(value)
+    }
+}
+
+/// Builder used to aid in construction of `SortFieldParams`
+#[derive(Debug, Clone)]
+#[must_use = "must be consumed to build a SortFieldParams"]
+pub struct SortFieldBuilder {
+    field: Field,
+    direction: Option<SortDirection>,
+    missing_value: Option<MissingValue>,
+}
+
+impl SortFieldBuilder {
+    /// create a new field sort
+    pub fn build(self) -> SortField {
+        SortField {
+            field: self.field,
+            direction: self.direction,
+            missing_value: self.missing_value,
+        }
+    }
+
+    /// Sort ascending
+    pub fn in_ascending_order(self) -> Self {
+        Self {
+            direction: Some(SortDirection::Ascending),
+            ..self
+        }
+    }
+
+    /// Sort descending
+    pub fn in_descending_order(self) -> Self {
+        Self {
+            direction: Some(SortDirection::Descending),
+            ..self
+        }
+    }
+
+    /// If the field is missing a value, use this in those cases
+    pub fn where_missing_use<V: Into<ScalarValue>>(self, value: V) -> Self {
+        Self {
+            missing_value: Some(MissingValue::Custom(value.into())),
+            ..self
+        }
+    }
+
+    /// Documents without a value are sorted last
+    pub fn with_missing_values_last(self) -> Self {
+        Self {
+            missing_value: Some(MissingValue::Last),
+            ..self
+        }
+    }
+
+    /// Documents without a value are sorted first
+    pub fn with_missing_values_first(self) -> Self {
+        Self {
+            missing_value: Some(MissingValue::First),
+            ..self
+        }
+    }
+}
+
+impl Serialize for SortField {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        #[derive(Serialize)]
+        struct Params<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            order: &'a Option<SortDirection>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            missing: &'a Option<MissingValue>,
+        }
+
+        if self.direction.is_none() && self.missing_value.is_none() {
+            return self.field.serialize(serializer);
+        }
+
+        let mut map = serializer.serialize_map(Some(1))?;
+
+        if let (Some(direction), None) = (&self.direction, &self.missing_value) {
+            map.serialize_entry(&self.field, direction)?;
+            return map.end();
+        }
+
+        let params = Params {
+            order: &self.direction,
+            missing: &self.missing_value,
+        };
+
+        map.serialize_entry(&self.field, &params)?;
+        map.end()
+    }
+}

--- a/src/request/search/sort_directive/geo_params.rs
+++ b/src/request/search/sort_directive/geo_params.rs
@@ -1,0 +1,192 @@
+use super::*;
+use serde::{ser::SerializeMap, Serialize};
+
+/// Information needed to sort results from
+/// a geo-point location
+#[derive(Debug, Clone)]
+pub struct SortGeo {
+    pub(super) field: Field,
+    pub(super) location: GeoPoint,
+    pub(super) order: Option<SortDirection>,
+    pub(super) ignore_unmapped: Option<bool>,
+    pub(super) calc_formula: Option<CalculationFormula>,
+}
+
+impl SortGeo {
+    /// Starts construction on a geo-distance sort
+    pub fn field_and_location<F, P>(field: F, location: P) -> SortGeoBuilder
+    where
+        F: Into<Field>,
+        P: IntoGeoPoint,
+    {
+        SortGeoBuilder {
+            field: field.into(),
+            location: location.into_geo_point(),
+            order: None,
+            ignore_unmapped: None,
+            calc_formula: None,
+        }
+    }
+}
+
+impl From<SortGeo> for SortDirective {
+    fn from(value: SortGeo) -> Self {
+        Self::GeoDistance(value)
+    }
+}
+
+/// Aids in construcution of a geo-distance sort
+#[derive(Debug, Clone)]
+#[must_use = "must call build() to creat a geo-distance sort"]
+pub struct SortGeoBuilder {
+    field: Field,
+    location: GeoPoint,
+    order: Option<SortDirection>,
+    ignore_unmapped: Option<bool>,
+    calc_formula: Option<CalculationFormula>,
+}
+
+impl SortGeoBuilder {
+    /// finish construction of a geo-distance sort
+    pub fn build(self) -> SortGeo {
+        SortGeo {
+            field: self.field,
+            location: self.location,
+            order: self.order,
+            ignore_unmapped: self.ignore_unmapped,
+            calc_formula: self.calc_formula,
+        }
+    }
+
+    /// Sort ascending
+    pub fn in_ascending_order(self) -> Self {
+        Self {
+            order: Some(SortDirection::Ascending),
+            ..self
+        }
+    }
+
+    /// Sort descending
+    pub fn in_descending_order(self) -> Self {
+        Self {
+            order: Some(SortDirection::Descending),
+            ..self
+        }
+    }
+
+    /// Arc is normally the default, and most accurate
+    pub fn using_the_arc_formula(self) -> Self {
+        Self {
+            calc_formula: Some(CalculationFormula::Arc),
+            ..self
+        }
+    }
+
+    /// Plane is less accurate, especially over longer
+    /// distances and near the poles; however, it is much
+    /// faster
+    pub fn using_the_plane_formula(self) -> Self {
+        Self {
+            calc_formula: Some(CalculationFormula::Plane),
+            ..self
+        }
+    }
+
+    /// By default Elasticsearch will error on a document
+    /// if it's missing the field being used; setting this
+    /// will instead allow the search to work and the documents
+    /// missing the distance will be considered "Infinity"
+    pub fn ignore_unmapped_documents(self) -> Self {
+        Self {
+            ignore_unmapped: Some(true),
+            ..self
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(super) enum CalculationFormula {
+    Arc,
+    Plane,
+}
+
+impl Serialize for CalculationFormula {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Arc => "arc".serialize(serializer),
+            Self::Plane => "plane".serialize(serializer),
+        }
+    }
+}
+
+impl Serialize for SortGeo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        struct Params<'a> {
+            field: &'a Field,
+            location: &'a GeoPoint,
+            order: &'a Option<SortDirection>,
+            ignore_unmapped: &'a Option<bool>,
+            calc_formula: &'a Option<CalculationFormula>,
+        }
+
+        impl<'a> Params<'a> {
+            fn map_size(&self) -> usize {
+                [
+                    self.order.is_some(),
+                    self.ignore_unmapped.is_some(),
+                    self.calc_formula.is_some(),
+                ]
+                .iter()
+                .filter(|something| **something)
+                .count()
+                    + 1
+            }
+
+            fn borrow(sort_geo: &'a SortGeo) -> Self {
+                Self {
+                    field: &sort_geo.field,
+                    location: &sort_geo.location,
+                    order: &sort_geo.order,
+                    ignore_unmapped: &sort_geo.ignore_unmapped,
+                    calc_formula: &sort_geo.calc_formula,
+                }
+            }
+        }
+
+        impl<'a> Serialize for Params<'a> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                let mut map = serializer.serialize_map(Some(self.map_size()))?;
+
+                map.serialize_entry(self.field, self.location)?;
+
+                if let Some(order) = self.order {
+                    map.serialize_entry("order", order)?;
+                }
+
+                if let Some(formula) = self.calc_formula {
+                    map.serialize_entry("distance_type", formula)?;
+                }
+
+                if let Some(ignore) = self.ignore_unmapped {
+                    map.serialize_entry("ignore_unmapped", ignore)?;
+                }
+
+                map.end()
+            }
+        }
+
+        let params = Params::borrow(self);
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry("_geo_distance", &params)?;
+        map.end()
+    }
+}

--- a/src/request/search/sort_directive/missing_value.rs
+++ b/src/request/search/sort_directive/missing_value.rs
@@ -1,0 +1,28 @@
+use serde::Serialize;
+
+use super::*;
+
+/// How documents which are missing are treated
+/// during a sort
+#[derive(Debug, Clone)]
+pub enum MissingValue {
+    /// put them at the front
+    First,
+    /// put them at the back
+    Last,
+    /// use this value for the sort
+    Custom(ScalarValue),
+}
+
+impl Serialize for MissingValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::First => "_first".serialize(serializer),
+            Self::Last => "_last".serialize(serializer),
+            Self::Custom(value) => value.serialize(serializer),
+        }
+    }
+}

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -519,3 +519,67 @@ fn building_a_search_with_stats_a_missing_value() {
         })
     );
 }
+
+#[test]
+fn building_a_search_with_a_geo_sort() {
+    let mut search = Search::default();
+    use elastic_lens::request::search::GeoPoint;
+
+    search
+        .sort_field("user.location")
+        .by_distance_from(GeoPoint::default())
+        .using_the_plane_formula()
+        .in_ascending_order()
+        .ignore_unmapped_documents();
+
+    assert_eq!(
+        search_to_json(search),
+        json!({
+            "sort": [
+                {
+                    "_geo_distance": {
+                        "user.location": { "lat": 0.0, "lon": 0.0 },
+                        "order": "asc",
+                        "distance_type": "plane",
+                        "ignore_unmapped": true
+                    }
+                }
+            ]
+        })
+    );
+}
+
+#[test]
+fn building_a_search_with_a_normal_field_sort() {
+    let mut search = Search::default();
+
+    search.sort_field("user.age").descending();
+
+    assert_eq!(
+        search_to_json(search),
+        json!({
+            "sort": [
+                { "user.age": "desc" }
+            ]
+        })
+    );
+}
+
+#[test]
+fn building_a_search_with_a_normal_field_sort_and_missing_value() {
+    let mut search = Search::default();
+
+    search
+        .sort_field("user.age")
+        .ascending()
+        .where_missing_use(42);
+
+    assert_eq!(
+        search_to_json(search),
+        json!({
+            "sort": [
+                { "user.age": { "order": "asc", "missing": 42 } }
+            ]
+        })
+    );
+}

--- a/tests/sort_directive_field_params_test.rs
+++ b/tests/sort_directive_field_params_test.rs
@@ -1,0 +1,95 @@
+use elastic_lens::request::search::SortField;
+use serde_json::json;
+
+fn to_json<S: serde::Serialize>(value: S) -> serde_json::Value {
+    serde_json::to_value(value).unwrap()
+}
+
+#[test]
+fn just_a_field_name() {
+    let sort = SortField::field("user.score").build();
+
+    assert_eq!(to_json(sort), json!("user.score"));
+}
+
+#[test]
+fn field_with_missing_last() {
+    let sort = SortField::field("user.score")
+        .with_missing_values_last()
+        .build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "user.score": { "missing": "_last" }
+        })
+    );
+}
+
+#[test]
+fn field_with_missing_first() {
+    let sort = SortField::field("user.score")
+        .with_missing_values_first()
+        .build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "user.score": { "missing": "_first" }
+        })
+    );
+}
+
+#[test]
+fn with_a_custom_missing_value() {
+    let sort = SortField::field("user.score").where_missing_use(42).build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "user.score": { "missing": 42 }
+        })
+    );
+}
+
+#[test]
+fn with_a_sort_direction_of_ascending() {
+    let sort = SortField::field("user.score").in_ascending_order().build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "user.score": "asc"
+        })
+    );
+}
+
+#[test]
+fn with_a_sort_direction_of_descending() {
+    let sort = SortField::field("user.score").in_descending_order().build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "user.score": "desc"
+        })
+    );
+}
+
+#[test]
+fn with_sort_direction_and_missing_criteria() {
+    let sort = SortField::field("user.score")
+        .in_descending_order()
+        .where_missing_use(42)
+        .build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "user.score": {
+                "order": "desc",
+                "missing": 42
+            }
+        })
+    );
+}

--- a/tests/sort_directive_geo_distance_test.rs
+++ b/tests/sort_directive_geo_distance_test.rs
@@ -1,0 +1,128 @@
+use elastic_lens::request::search::{GeoPoint, SortGeo};
+use serde_json::json;
+
+fn to_json<S: serde::Serialize>(value: S) -> serde_json::Value {
+    serde_json::to_value(value).unwrap()
+}
+
+const GEO_POINT: GeoPoint = GeoPoint { lat: 1.1, lon: 2.2 };
+
+#[test]
+fn simple_geo_distance_sort() {
+    let sort = SortGeo::field_and_location("user.location", GEO_POINT).build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "_geo_distance": {
+                "user.location": { "lat": 1.1, "lon": 2.2 }
+            }
+        })
+    );
+}
+
+#[test]
+fn geo_distance_sort_with_arc_formula() {
+    let sort = SortGeo::field_and_location("user.loc", GEO_POINT)
+        .using_the_arc_formula()
+        .build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "_geo_distance": {
+                "user.loc": { "lat": 1.1, "lon": 2.2 },
+                "distance_type": "arc"
+            }
+        })
+    );
+}
+
+#[test]
+fn geo_distance_sort_with_plane_formula() {
+    let sort = SortGeo::field_and_location("user.loc", GEO_POINT)
+        .using_the_plane_formula()
+        .build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "_geo_distance": {
+                "user.loc": { "lat": 1.1, "lon": 2.2 },
+                "distance_type": "plane"
+            }
+        })
+    );
+}
+
+#[test]
+fn geo_distance_sort_ignoring_unmapped() {
+    let sort = SortGeo::field_and_location("user.loc", GEO_POINT)
+        .ignore_unmapped_documents()
+        .build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "_geo_distance": {
+                "user.loc": { "lat": 1.1, "lon": 2.2 },
+                "ignore_unmapped": true
+            }
+        })
+    );
+}
+
+#[test]
+fn geo_distance_sort_asc() {
+    let sort = SortGeo::field_and_location("user.loc", GEO_POINT)
+        .in_ascending_order()
+        .build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "_geo_distance": {
+                "user.loc": { "lat": 1.1, "lon": 2.2 },
+                "order": "asc"
+            }
+        })
+    );
+}
+
+#[test]
+fn geo_distance_sort_desc() {
+    let sort = SortGeo::field_and_location("user.loc", GEO_POINT)
+        .in_descending_order()
+        .build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "_geo_distance": {
+                "user.loc": { "lat": 1.1, "lon": 2.2 },
+                "order": "desc"
+            }
+        })
+    );
+}
+
+#[test]
+fn geo_distance_with_everything() {
+    let sort = SortGeo::field_and_location("user.loc", GEO_POINT)
+        .in_descending_order()
+        .using_the_plane_formula()
+        .ignore_unmapped_documents()
+        .build();
+
+    assert_eq!(
+        to_json(sort),
+        json!({
+            "_geo_distance": {
+                "user.loc": { "lat": 1.1, "lon": 2.2 },
+                "order": "desc",
+                "ignore_unmapped": true,
+                "distance_type": "plane"
+            }
+        })
+    );
+}


### PR DESCRIPTION
This introduces two initial sorts:

- geo-distance sort
- simple field sort

Both of these are heavily used by me and
felt like the minimum sorts to get done.

I plan to implement a script score in a
separate body of work as I suspect it's
going a bit more to wire up.