### PR TITLE
Fix `pub_field!` Macro and add Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pub fn create_client() -> Result<Client<DefaultAdapter>, Error> {
 
 ```rust
 // See `examples/inventory_item.rs` for definition
-use super::inventory_item::InventoryItem;
+use super::inventory_item::*;
 
 use elastic_lens::{prelude::*, response::SearchResults, Error};
 
@@ -48,8 +48,8 @@ pub async fn clothing_inventory() -> Result<SearchResults<InventoryItem>, Error>
     let client = create_client()?;
 
     let mut search = Search::default();
-    search.with(field("category").contains("clothing"));
-    search.with(field("cost").greater_than(500));
+    search.with(CATEGORY.contains("clothing"));
+    search.with(COST.greater_than(500));
 
     Ok(client.search(&search).await?)
 }
@@ -96,17 +96,17 @@ pub async fn complex_search() -> Result<SearchResults<Value>, Error> {
 ### MultiSearch
 
 ```rust
-use super::inventory_item::InventoryItem;
+use super::inventory_item::*;
 use elastic_lens::{prelude::*, Error};
 
 pub async fn report_clothing_and_office() -> Result<(), Error> {
     let client = create_client()?;
 
     let mut clothing = Search::default();
-    clothing.with(field("category").contains("clothing"));
+    clothing.with(CATEGORY.contains("clothing"));
 
     let mut office = Search::default();
-    office.with(field("category").contains("office"));
+    office.with(CATEGORY.contains("office"));
 
     let results = client
         .multi_search::<InventoryItem>(&[clothing, office])
@@ -221,6 +221,7 @@ pub async fn collect_price_stats() -> Result<Stats, Error> {
 ### Filter Aggregations
 
 ```rust
+use super::inventory_item::*;
 use elastic_lens::{prelude::*, Error};
 
 pub async fn less_than_20_report() -> Result<Filtered, Error> {
@@ -230,7 +231,7 @@ pub async fn less_than_20_report() -> Result<Filtered, Error> {
 
     search
         .create_aggregation("under-twenty")
-        .filtered_by(|search| search.with(field("cost").less_than(20_00)))
+        .filtered_by(|search| search.with(COST.less_than(20_00)))
         .with_sub_aggregations(|aggs| {
             aggs.create_aggregation("categories")
                 .for_field("category")

--- a/examples/inventory_item.rs
+++ b/examples/inventory_item.rs
@@ -1,4 +1,10 @@
+use elastic_lens::pub_field;
 use serde::Deserialize;
+
+pub_field!(CATEGORY, "category");
+pub_field!(SUB_CATEGORY, "sub_category");
+pub_field!(ACTIVE, "active");
+pub_field!(COST, "cost");
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct InventoryItem {

--- a/examples/sample_code.rs
+++ b/examples/sample_code.rs
@@ -17,7 +17,7 @@ pub mod create_client {
 }
 
 pub mod create_an_run_search {
-    use super::inventory_item::InventoryItem;
+    use super::inventory_item::*;
     use crate::create_client::create_client;
     use elastic_lens::{prelude::*, response::SearchResults, Error};
 
@@ -25,8 +25,8 @@ pub mod create_an_run_search {
         let client = create_client()?;
 
         let mut search = Search::default();
-        search.with(field("category").contains("clothing"));
-        search.with(field("cost").greater_than(500));
+        search.with(CATEGORY.contains("clothing"));
+        search.with(COST.greater_than(500));
 
         Ok(client.search(&search).await?)
     }
@@ -114,6 +114,7 @@ pub mod stats_aggregation {
 }
 
 pub mod filter_aggregation {
+    use super::inventory_item::*;
     use crate::create_client::create_client;
     use elastic_lens::{prelude::*, Error};
 
@@ -124,7 +125,7 @@ pub mod filter_aggregation {
 
         search
             .create_aggregation("under-twenty")
-            .filtered_by(|search| search.with(field("cost").less_than(20_00)))
+            .filtered_by(|search| search.with(COST.less_than(20_00)))
             .with_sub_aggregations(|aggs| {
                 aggs.create_aggregation("categories")
                     .for_field("category")
@@ -143,7 +144,7 @@ pub mod filter_aggregation {
 }
 
 pub mod multi_search {
-    use super::inventory_item::InventoryItem;
+    use super::inventory_item::*;
     use crate::create_client::create_client;
     use elastic_lens::{prelude::*, Error};
 
@@ -151,10 +152,10 @@ pub mod multi_search {
         let client = create_client()?;
 
         let mut clothing = Search::default();
-        clothing.with(field("category").contains("clothing"));
+        clothing.with(CATEGORY.contains("clothing"));
 
         let mut office = Search::default();
-        office.with(field("category").contains("office"));
+        office.with(CATEGORY.contains("office"));
 
         let results = client
             .multi_search::<InventoryItem>(&[clothing, office])

--- a/examples/simple_search.rs
+++ b/examples/simple_search.rs
@@ -2,7 +2,7 @@ mod inventory_item;
 
 use elastic_lens::prelude::*;
 use elastic_lens::Error;
-use inventory_item::InventoryItem;
+use inventory_item::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -13,9 +13,9 @@ async fn main() -> Result<(), Error> {
 
     let mut search = Search::default();
 
-    search.with(field("category").contains("clothing"));
-    search.with(!field("sub_category").contains("beanie"));
-    search.with(field("cost").between(1000..2000));
+    search.with(CATEGORY.contains("clothing"));
+    search.with(!SUB_CATEGORY.contains("beanie"));
+    search.with(COST.between(1000..2000));
 
     search.set_limit(10);
 

--- a/src/request/search/field.rs
+++ b/src/request/search/field.rs
@@ -56,6 +56,7 @@ impl Serialize for Field {
 macro_rules! pub_field {
     ($name:ident, $value:literal) => {
         /// Field for $value
-        pub const $name: $crate::search::Field = $crate::search::Field::static_field($value);
+        pub const $name: $crate::request::search::Field =
+            $crate::request::search::Field::static_field($value);
     };
 }


### PR DESCRIPTION
The resolution of the macro was not working. It wasn't caught until trying to wire it up in an example and I found it.  This fixes the problem and adds it into the examples.  With it being there it will keep getting tested.