### PR TITLE
Add Script-Score Sort Support & Refactor Sort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,5 @@ jobs:
         run: cargo run --example multi_search
       - name: 'Example: simple_sort'
         run: cargo run --example simple_sort
+      - name: 'Example: script_sort'
+        run: cargo run --example script_sort

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ path = "examples/multi_search.rs"
 name = "simple_sort"
 path = "examples/simple_sort.rs"
 
+[[example]]
+name = "script_sort"
+path = "examples/script_sort.rs"
+
 # To avoid repeating the same model over and
 # over between examples this serves as a shared
 # lib for them

--- a/README.md
+++ b/README.md
@@ -138,10 +138,7 @@ pub async fn five_cheapest_items() -> Result<SearchResults<Value>, Error> {
     let client = create_client()?;
     let mut search = Search::default();
 
-    search
-        .sort_field("cost")
-        .ascending()
-        .with_missing_values_last();
+    search.sort(by_field("cost").ascending().with_missing_values_last());
 
     search.set_limit(5);
 
@@ -162,11 +159,41 @@ pub async fn nearest_allies() -> Result<SearchResults<Value>, Error> {
 
     search.with(field("user.is_ally").contains(true));
 
-    search
-        .sort_field("user.location")
-        .by_distance_from(GeoPoint::new(1.1, 2.2))
-        .in_ascending_order()
-        .ignore_unmapped_documents();
+    search.sort(
+        by_field("user.location")
+            .by_distance_from(GeoPoint::new(1.1, 2.2))
+            .in_ascending_order()
+            .ignore_unmapped_documents(),
+    );
+
+    Ok(client.search(&search).await?)
+}
+```
+
+### Script Score Sorting
+
+```rust
+use super::inventory_item::*;
+use elastic_lens::{prelude::*, response::SearchResults, Error};
+
+pub async fn some_cheaper_first() -> Result<SearchResults<InventoryItem>, Error> {
+    let client = create_client()?;
+    let mut search = Search::default();
+
+    search.with(!SUB_CATEGORY.contains("beanie"));
+
+    search.sort(
+        by_script(
+            r#"
+              if ( doc['cost'].value > params.breakpoint ) {
+                  doc['cost'].value / 100
+              } else {
+                  doc['cost'].value * 100
+              }
+            "#,
+        )
+        .with_params([("breakpoint", 1300)]),
+    );
 
     Ok(client.search(&search).await?)
 }

--- a/examples/script_sort.rs
+++ b/examples/script_sort.rs
@@ -2,7 +2,7 @@ mod inventory_item;
 
 use elastic_lens::prelude::*;
 use elastic_lens::Error;
-use inventory_item::InventoryItem;
+use inventory_item::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -13,9 +13,24 @@ async fn main() -> Result<(), Error> {
 
     let mut search = Search::default();
 
-    search.sort(by_field("cost").ascending());
+    search.with(!SUB_CATEGORY.contains("beanie"));
+
+    search.sort(
+        by_script(
+            r#"
+              if ( doc['cost'].value > params.breakpoint ) {
+                  doc['cost'].value / 100
+              } else {
+                  doc['cost'].value * 100
+              }
+            "#,
+        )
+        .with_params([("breakpoint", 1300)]),
+    );
 
     let results = client.search::<InventoryItem>(&search).await?;
+
+    println!("{:?}", results.count());
 
     for doc in results.docs() {
         println!("{doc:?}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ pub use errors::*;
 pub mod prelude {
     pub use crate::client::Client;
     pub use crate::request::search::{
-        field, if_all_match, if_any_match, AggregationBuilder, CriteriaBuilder, IntoGeoPoint,
-        Search, SortBuilderTrait, SubAggregationBuilder,
+        by_field, by_script, field, if_all_match, if_any_match, AggregationBuilder,
+        CriteriaBuilder, IntoGeoPoint, Search, SortBuilderTrait, SubAggregationBuilder,
     };
     pub use crate::request::MultiSearch;
     pub use crate::response::{Filtered, NumericTerms, Stats, StringTerms};

--- a/src/request/search/body.rs
+++ b/src/request/search/body.rs
@@ -8,15 +8,9 @@ impl<'a, S: SearchTrait> From<&'a S> for SearchBody<'a> {
         Self {
             size: value.limit(),
             from: value.offset(),
-            query: ElasticsearchQuery {
-                bool: ElasticsearchBool {
-                    filter: value.positive_criteria(),
-                    must_not: value.negative_criteria(),
-                    should: None,
-                },
-            },
+            query: determine_root(value),
             aggs: value.aggregations(),
-            sort: value.sort_directives(),
+            sort: determine_sorts(value),
         }
     }
 }
@@ -30,6 +24,27 @@ impl<'a> SearchBody<'a> {
     }
 }
 
+#[derive(Debug)]
+#[doc(hidden)]
+pub enum QueryRoot<'a> {
+    RootQuery(ElasticsearchQuery<'a>),
+    ScriptScore(ScriptScoreRoot<'a>),
+}
+
+#[derive(Debug, Serialize)]
+#[doc(hidden)]
+pub struct ScriptScoreRoot<'a> {
+    script_score: ScriptScoreValues<'a>,
+}
+
+#[derive(Debug, Serialize)]
+#[doc(hidden)]
+pub struct ScriptScoreValues<'a> {
+    #[serde(skip_serializing_if = "SkipNode::not_needed")]
+    query: ElasticsearchQuery<'a>,
+    script: &'a SortDirective,
+}
+
 #[derive(Debug, Serialize)]
 #[doc(hidden)]
 pub struct SearchBody<'a> {
@@ -40,7 +55,7 @@ pub struct SearchBody<'a> {
     from: Option<usize>,
 
     #[serde(skip_serializing_if = "SkipNode::not_needed")]
-    query: ElasticsearchQuery<'a>,
+    query: QueryRoot<'a>,
 
     #[serde(skip_serializing_if = "SkipNode::not_needed")]
     aggs: Option<&'a AggCollection>,
@@ -67,6 +82,55 @@ pub struct ElasticsearchBool<'a> {
 
     #[serde(skip_serializing_if = "SkipNode::not_needed")]
     pub(super) should: Option<&'a Vec<Criterion>>,
+}
+
+fn determine_root<S: SearchTrait>(search: &S) -> QueryRoot<'_> {
+    if has_a_script_sort(search) {
+        QueryRoot::ScriptScore(ScriptScoreRoot {
+            script_score: ScriptScoreValues {
+                query: ElasticsearchQuery {
+                    bool: ElasticsearchBool {
+                        filter: search.positive_criteria(),
+                        must_not: search.negative_criteria(),
+                        should: None,
+                    },
+                },
+                script: fetch_script(search),
+            },
+        })
+    } else {
+        QueryRoot::RootQuery(ElasticsearchQuery {
+            bool: ElasticsearchBool {
+                filter: search.positive_criteria(),
+                must_not: search.negative_criteria(),
+                should: None,
+            },
+        })
+    }
+}
+
+fn determine_sorts<S: SearchTrait>(search: &S) -> Option<&Vec<SortDirective>> {
+    if has_a_script_sort(search) {
+        None
+    } else {
+        search.sort_directives()
+    }
+}
+
+fn has_a_script_sort<S: SearchTrait>(search: &S) -> bool {
+    match search.sort_directives() {
+        None => false,
+        Some(sorts) => sorts.iter().any(SortDirective::is_script_score),
+    }
+}
+
+fn fetch_script<S: SearchTrait>(search: &S) -> &SortDirective {
+    search
+        .sort_directives()
+        .unwrap()
+        .iter()
+        .find(|sort| sort.is_script_score())
+        .unwrap()
 }
 
 trait SkipNode {
@@ -104,5 +168,26 @@ impl<'a> SkipNode for ElasticsearchBool<'a> {
 impl<'a> SkipNode for ElasticsearchQuery<'a> {
     fn is_needed(&self) -> bool {
         self.bool.is_needed()
+    }
+}
+
+impl<'a> SkipNode for QueryRoot<'a> {
+    fn is_needed(&self) -> bool {
+        match self {
+            Self::ScriptScore(_) => true,
+            Self::RootQuery(quey) => quey.is_needed(),
+        }
+    }
+}
+
+impl<'a> Serialize for QueryRoot<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::RootQuery(body) => body.serialize(serializer),
+            Self::ScriptScore(body) => body.serialize(serializer),
+        }
     }
 }

--- a/src/request/search/sort_directive.rs
+++ b/src/request/search/sort_directive.rs
@@ -6,12 +6,14 @@ mod direction;
 mod field_params;
 mod geo_params;
 mod missing_value;
+mod script_score;
 
 pub use builder_trait::*;
 pub use direction::*;
 pub use field_params::*;
 pub use geo_params::*;
 pub use missing_value::*;
+pub use script_score::*;
 
 /// Describes a way to sort documents from a search
 #[derive(Debug, Clone)]
@@ -21,6 +23,19 @@ pub enum SortDirective {
 
     /// Sort from GeoPoint
     GeoDistance(SortGeo),
+
+    /// When sorting with a script score
+    ScriptScore(ScriptScoreData),
+}
+
+impl SortDirective {
+    /// Determines if the sort is a script-score sort.
+    /// This kind of sort is presented much differently
+    /// to Elasticsearch so the distinction needs to be
+    /// known.
+    pub(crate) fn is_script_score(&self) -> bool {
+        matches!(self, Self::ScriptScore(_))
+    }
 }
 
 impl Serialize for SortDirective {
@@ -31,6 +46,7 @@ impl Serialize for SortDirective {
         match self {
             Self::Field(params) => params.serialize(serializer),
             Self::GeoDistance(params) => params.serialize(serializer),
+            Self::ScriptScore(params) => params.serialize(serializer),
         }
     }
 }

--- a/src/request/search/sort_directive/builder_trait.rs
+++ b/src/request/search/sort_directive/builder_trait.rs
@@ -1,24 +1,37 @@
 use super::*;
+use std::borrow::Cow;
 
 mod field_sort_builder;
 mod field_sort_builder_options;
 mod geo_distance_sort_builder;
+mod script_sort_builder;
 
 pub use field_sort_builder::*;
 pub use field_sort_builder_options::*;
 pub use geo_distance_sort_builder::*;
+pub use script_sort_builder::*;
+
+/// Use a field to sort by, this can be just the field in a
+/// normal direction sort or some kind of distance sort.
+pub fn by_field<F: Into<Field>>(field: F) -> FieldSortBuilder {
+    FieldSortBuilder {
+        field: field.into(),
+    }
+}
+
+/// Use to sort by a script-score.
+pub fn by_script<S: Into<Cow<'static, str>>>(script: S) -> ScriptScoreBuilder {
+    ScriptScoreBuilder::new(script)
+}
 
 /// Trait used to provide self-sort construction
 pub trait SortBuilderTrait {
     /// mutable reference to sorts you want to build on
     fn sort_directives_mut(&mut self) -> &mut Vec<SortDirective>;
 
-    /// Target a field to sort
-    fn sort_field<F: Into<Field>>(&mut self, field: F) -> FieldSortBuilder<'_> {
-        FieldSortBuilder {
-            field: field.into(),
-            sorts: self.sort_directives_mut(),
-        }
+    /// Add a directive by which to sort results.
+    fn sort<S: Into<SortDirective>>(&mut self, sort: S) {
+        self.sort_directives_mut().push(sort.into());
     }
 }
 

--- a/src/request/search/sort_directive/builder_trait/field_sort_builder.rs
+++ b/src/request/search/sort_directive/builder_trait/field_sort_builder.rs
@@ -3,21 +3,18 @@ use super::*;
 /// The first step towards building a sort where a document
 /// field is the target
 #[derive(Debug)]
-#[must_use = "A selection must be made to build a sort"]
-pub struct FieldSortBuilder<'a> {
+pub struct FieldSortBuilder {
     pub(super) field: Field,
-    pub(super) sorts: &'a mut Vec<SortDirective>,
 }
 
-impl<'a> FieldSortBuilder<'a> {
+impl FieldSortBuilder {
     /// Creates a geo-distance sort. There are a number of options
     /// you can add to this sort, but when you end the chain it
     /// will build with whatever options you take.
-    pub fn by_distance_from<P: IntoGeoPoint>(self, location: P) -> GeoDistanceSortBuilder<'a> {
+    pub fn by_distance_from<P: IntoGeoPoint>(self, location: P) -> GeoDistanceSortBuilder {
         GeoDistanceSortBuilder {
             field: self.field,
             location: location.into_geo_point(),
-            sorts: self.sorts,
             order: None,
             ignore_unmapped: None,
             calc_formula: None,
@@ -25,22 +22,30 @@ impl<'a> FieldSortBuilder<'a> {
     }
 
     /// sort field in decending order
-    pub fn descending(self) -> FieldSortBuilderOptions<'a> {
+    pub fn descending(self) -> FieldSortBuilderOptions {
         FieldSortBuilderOptions {
             field: self.field,
-            sorts: self.sorts,
             direction: SortDirection::Descending,
             missing_value: None,
         }
     }
 
     /// sort field in ascending order
-    pub fn ascending(self) -> FieldSortBuilderOptions<'a> {
+    pub fn ascending(self) -> FieldSortBuilderOptions {
         FieldSortBuilderOptions {
             field: self.field,
-            sorts: self.sorts,
             direction: SortDirection::Ascending,
             missing_value: None,
         }
+    }
+}
+
+impl From<FieldSortBuilder> for SortDirective {
+    fn from(value: FieldSortBuilder) -> Self {
+        Self::Field(SortField {
+            field: value.field,
+            direction: None,
+            missing_value: None,
+        })
     }
 }

--- a/src/request/search/sort_directive/builder_trait/field_sort_builder_options.rs
+++ b/src/request/search/sort_directive/builder_trait/field_sort_builder_options.rs
@@ -2,43 +2,38 @@ use super::*;
 
 /// Aids in finishing a field sort for a search
 #[derive(Debug)]
-pub struct FieldSortBuilderOptions<'a> {
+pub struct FieldSortBuilderOptions {
     pub(super) field: Field,
-    pub(super) sorts: &'a mut Vec<SortDirective>,
     pub(super) direction: SortDirection,
     pub(super) missing_value: Option<MissingValue>,
 }
 
-impl<'a> FieldSortBuilderOptions<'a> {
+impl FieldSortBuilderOptions {
     /// If the field is missing a value, use this in those cases
-    pub fn where_missing_use<V: Into<ScalarValue>>(mut self, value: V) {
+    pub fn where_missing_use<V: Into<ScalarValue>>(mut self, value: V) -> Self {
         self.missing_value = Some(MissingValue::Custom(value.into()));
+        self
     }
 
     /// Documents without a value are sorted last
-    pub fn with_missing_values_last(mut self) {
+    pub fn with_missing_values_last(mut self) -> Self {
         self.missing_value = Some(MissingValue::Last);
+        self
     }
 
     /// Documents without a value are sorted first
-    pub fn with_missing_values_first(mut self) {
+    pub fn with_missing_values_first(mut self) -> Self {
         self.missing_value = Some(MissingValue::First);
+        self
     }
 }
 
-impl<'a> Drop for FieldSortBuilderOptions<'a> {
-    fn drop(&mut self) {
-        let mut field = "".into();
-        let mut direction = SortDirection::Ascending;
-        std::mem::swap(&mut field, &mut self.field);
-        std::mem::swap(&mut direction, &mut self.direction);
-
-        let sort = SortField {
-            field,
-            direction: Some(direction),
-            missing_value: self.missing_value.take(),
-        };
-
-        self.sorts.push(sort.into());
+impl From<FieldSortBuilderOptions> for SortDirective {
+    fn from(value: FieldSortBuilderOptions) -> Self {
+        Self::Field(SortField {
+            field: value.field,
+            direction: Some(value.direction),
+            missing_value: value.missing_value,
+        })
     }
 }

--- a/src/request/search/sort_directive/builder_trait/geo_distance_sort_builder.rs
+++ b/src/request/search/sort_directive/builder_trait/geo_distance_sort_builder.rs
@@ -2,30 +2,29 @@ use super::*;
 
 /// Aids in building a geo-distance sort for `FieldSortBuilder`
 #[derive(Debug)]
-pub struct GeoDistanceSortBuilder<'a> {
+pub struct GeoDistanceSortBuilder {
     pub(super) field: Field,
     pub(super) location: GeoPoint,
-    pub(super) sorts: &'a mut Vec<SortDirective>,
     pub(super) order: Option<SortDirection>,
     pub(super) ignore_unmapped: Option<bool>,
     pub(super) calc_formula: Option<CalculationFormula>,
 }
 
-impl GeoDistanceSortBuilder<'_> {
+impl GeoDistanceSortBuilder {
     /// Sort ascending
-    pub fn in_ascending_order(&mut self) -> &mut Self {
+    pub fn in_ascending_order(mut self) -> Self {
         self.order = Some(SortDirection::Ascending);
         self
     }
 
     /// Sort descending
-    pub fn in_descending_order(&mut self) -> &mut Self {
+    pub fn in_descending_order(mut self) -> Self {
         self.order = Some(SortDirection::Descending);
         self
     }
 
     /// Arc is normally the default, and most accurate
-    pub fn using_the_arc_formula(&mut self) -> &mut Self {
+    pub fn using_the_arc_formula(mut self) -> Self {
         self.calc_formula = Some(CalculationFormula::Arc);
         self
     }
@@ -33,7 +32,7 @@ impl GeoDistanceSortBuilder<'_> {
     /// Plane is less accurate, especially over longer
     /// distances and near the poles; however, it is much
     /// faster
-    pub fn using_the_plane_formula(&mut self) -> &mut Self {
+    pub fn using_the_plane_formula(mut self) -> Self {
         self.calc_formula = Some(CalculationFormula::Plane);
         self
     }
@@ -42,27 +41,20 @@ impl GeoDistanceSortBuilder<'_> {
     /// if it's missing the field being used; setting this
     /// will instead allow the search to work and the documents
     /// missing the distance will be considered "Infinity"
-    pub fn ignore_unmapped_documents(&mut self) -> &mut Self {
+    pub fn ignore_unmapped_documents(mut self) -> Self {
         self.ignore_unmapped = Some(true);
         self
     }
 }
 
-impl Drop for GeoDistanceSortBuilder<'_> {
-    fn drop(&mut self) {
-        let mut field = "".into();
-        let mut location = GeoPoint::default();
-        std::mem::swap(&mut field, &mut self.field);
-        std::mem::swap(&mut location, &mut self.location);
-
-        let sort = SortGeo {
-            field,
-            location,
-            order: self.order.take(),
-            ignore_unmapped: self.ignore_unmapped.take(),
-            calc_formula: self.calc_formula.take(),
-        };
-
-        self.sorts.push(sort.into());
+impl From<GeoDistanceSortBuilder> for SortDirective {
+    fn from(value: GeoDistanceSortBuilder) -> Self {
+        Self::GeoDistance(SortGeo {
+            field: value.field,
+            location: value.location,
+            order: value.order,
+            ignore_unmapped: value.ignore_unmapped,
+            calc_formula: value.calc_formula,
+        })
     }
 }

--- a/src/request/search/sort_directive/builder_trait/script_sort_builder.rs
+++ b/src/request/search/sort_directive/builder_trait/script_sort_builder.rs
@@ -1,0 +1,41 @@
+use super::*;
+use std::borrow::Cow;
+
+/// Aids in the construction of a script score
+#[derive(Debug, Clone)]
+pub struct ScriptScoreBuilder {
+    script: Cow<'static, str>,
+    params: Option<ScriptParams>,
+}
+
+impl ScriptScoreBuilder {
+    /// Start the construction of a script score
+    pub fn new<S: Into<Cow<'static, str>>>(script: S) -> Self {
+        Self {
+            script: script.into(),
+            params: None,
+        }
+    }
+
+    /// Attach params to the script score
+    pub fn with_params<P: Into<ScriptParams>>(self, params: P) -> Self {
+        Self {
+            params: Some(params.into()),
+            ..self
+        }
+    }
+
+    /// Create a new script-score
+    pub fn build(self) -> ScriptScoreData {
+        ScriptScoreData {
+            script: self.script,
+            params: self.params.unwrap_or_default(),
+        }
+    }
+}
+
+impl From<ScriptScoreBuilder> for SortDirective {
+    fn from(value: ScriptScoreBuilder) -> Self {
+        value.build().into()
+    }
+}

--- a/src/request/search/sort_directive/script_score.rs
+++ b/src/request/search/sort_directive/script_score.rs
@@ -1,0 +1,44 @@
+use super::*;
+use serde::Serialize;
+use std::borrow::Cow;
+
+mod params;
+pub use params::*;
+
+/// Data used to build a `script_score` for an Elasticsearch
+/// request.  Currently this is not a full representation of
+/// what is used, but instead the most common.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ScriptScoreData {
+    #[serde(rename = "source")]
+    pub(super) script: Cow<'static, str>,
+    #[serde(skip_serializing_if = "ScriptParams::is_empty")]
+    pub(super) params: ScriptParams,
+}
+
+impl ScriptScoreData {
+    /// Creates a new script sort w/o any params
+    pub fn new<S: Into<Cow<'static, str>>>(script: S) -> Self {
+        Self {
+            script: script.into(),
+            params: ScriptParams::default(),
+        }
+    }
+
+    /// Creates a new script sort with params
+    pub fn new_with_params<S>(script: S, params: ScriptParams) -> Self
+    where
+        S: Into<Cow<'static, str>>,
+    {
+        Self {
+            params,
+            script: script.into(),
+        }
+    }
+}
+
+impl From<ScriptScoreData> for SortDirective {
+    fn from(value: ScriptScoreData) -> Self {
+        Self::ScriptScore(value)
+    }
+}

--- a/src/request/search/sort_directive/script_score/params.rs
+++ b/src/request/search/sort_directive/script_score/params.rs
@@ -1,0 +1,92 @@
+use super::*;
+use serde::Serialize;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+#[doc(hidden)]
+pub enum ScriptValue {
+    Scalar(ScalarValue),
+    Array(Vec<ScalarValue>),
+}
+
+impl Serialize for ScriptValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Scalar(value) => value.serialize(serializer),
+            Self::Array(vec) => vec.serialize(serializer),
+        }
+    }
+}
+
+/// Data to be used by a script sort
+#[derive(Debug, Clone, Default)]
+pub struct ScriptParams {
+    data: HashMap<Cow<'static, str>, ScriptValue>,
+}
+
+impl<I, K, S> From<I> for ScriptParams
+where
+    S: Into<ScalarValue>,
+    K: Into<Cow<'static, str>>,
+    I: IntoIterator<Item = (K, S)>,
+{
+    fn from(value: I) -> Self {
+        let mut params = Self::default();
+        for (key, value) in value.into_iter() {
+            params
+                .data
+                .insert(key.into(), ScriptValue::Scalar(value.into()));
+        }
+        params
+    }
+}
+
+impl ScriptParams {
+    /// Use when you know how many params ahead of time you'll need
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: HashMap::with_capacity(capacity),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Add a single value
+    pub fn insert_scalar<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<Cow<'static, str>>,
+        V: Into<ScalarValue>,
+    {
+        let cow_key = key.into();
+        let scalar = ScriptValue::Scalar(value.into());
+        self.data.insert(cow_key, scalar);
+    }
+
+    /// Add an array of values
+    pub fn insert_array<K, V, S>(&mut self, key: K, value: V)
+    where
+        K: Into<Cow<'static, str>>,
+        S: Into<ScalarValue>,
+        V: IntoIterator<Item = S>,
+    {
+        let cow_key = key.into();
+        let vec = value.into_iter().map(Into::into).collect();
+        let array = ScriptValue::Array(vec);
+        self.data.insert(cow_key, array);
+    }
+}
+
+impl Serialize for ScriptParams {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.data.serialize(serializer)
+    }
+}

--- a/tests/script_score_params_test.rs
+++ b/tests/script_score_params_test.rs
@@ -1,0 +1,19 @@
+use elastic_lens::request::search::ScriptParams;
+use serde_json::{json, to_value};
+
+#[test]
+fn script_params_usage() {
+    let mut params = ScriptParams::with_capacity(4);
+    params.insert_scalar("lucky", 42);
+    params.insert_scalar("abort", true);
+    params.insert_array("values", [2, 4, 8]);
+
+    assert_eq!(
+        to_value(params).unwrap(),
+        json!({
+            "lucky": 42,
+            "abort": true,
+            "values": [2, 4, 8]
+        })
+    );
+}


### PR DESCRIPTION
This originally started as adding in the feature for script-score sorting. However; I have also added the same ergonomic changes to the sort system that were made with adding criteria to a search.

Now instead of longer sort chains from the search it accepts any builder into a `Sort`.  This allows them to be composable in the same way criteria are.

The introduction of the script-score into this code base is not in the final place I would like it to be.  The amount of logic which happens to shift the search body for this special search is quite a bit and needs a good refactor at some point.

While there are other items that could have added to the script-score I have elected to only add in the minimum needed to get this feature working.