### PR TITLE
Preperation for crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        feature: [offical_es7, offical_es8]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +28,7 @@ jobs:
           key: cargo-build-release-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Build Release
-        run: cargo build --release
+        run: cargo build --release --features=${{matrix.feature}}
 
   format:
     runs-on: ubuntu-latest
@@ -45,6 +48,9 @@ jobs:
         run: cargo fmt --check
 
   tests:
+    strategy:
+      matrix:
+        feature: [offical_es7, offical_es8]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -59,9 +65,12 @@ jobs:
           key: cargo-build-test-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Run Tests
-        run: cargo test
+        run: cargo test --features=${{matrix.feature}}
 
   clippy:
+    strategy:
+      matrix:
+        feature: [offical_es7, offical_es8]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -76,9 +85,12 @@ jobs:
           key: cargo-build-clippy-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Run Tests
-        run: cargo clippy
+        run: cargo clippy --features=${{matrix.feature}}
 
   examples:
+    strategy:
+      matrix:
+        feature: [offical_es7, offical_es8]
     runs-on: ubuntu-latest
     steps:
       - name: Configure sysctl limits
@@ -108,16 +120,16 @@ jobs:
       - name: load data
         run: ./bin/setup_index.sh
       - name: 'Example: fetch_a_document'
-        run: cargo run --example fetch_a_document
+        run: cargo run --features=${{matrix.feature}} --example fetch_a_document
       - name: 'Example: simple_search'
-        run: cargo run --example simple_search
+        run: cargo run --features=${{matrix.feature}} --example simple_search
       - name: 'Example: simple_aggs'
-        run: cargo run --example simple_aggs
+        run: cargo run --features=${{matrix.feature}} --example simple_aggs
       - name: 'Example: filter_aggs'
-        run: cargo run --example filter_aggs
+        run: cargo run --features=${{matrix.feature}} --example filter_aggs
       - name: 'Example: multi_search'
-        run: cargo run --example multi_search
+        run: cargo run --features=${{matrix.feature}} --example multi_search
       - name: 'Example: simple_sort'
-        run: cargo run --example simple_sort
+        run: cargo run --features=${{matrix.feature}} --example simple_sort
       - name: 'Example: script_sort'
-        run: cargo run --example script_sort
+        run: cargo run --features=${{matrix.feature}} --example script_sort

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 authors = [
   "Ben Falk <benjamin.falk@yahoo.com>"
 ]
+description = "An opinionated framework to work with Elasticsearch."
+license-file = "LICENSE.md"
+repository = "https://github.com/benfalk/elastic_lens"
+categories = ["framework"]
+keywords = ["elasticsearch"]
+readme = "README.md"
 
 # See more keys and their definitions at:
 #   https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -15,9 +21,15 @@ serde_json = { version = "1.0" }
 thiserror = { version = "1.0" }
 async-trait = { version = "0.1" }
 arraystring = { version = "0.3.0" }
+elastic_lens_offical_es7 = { version = "7", optional = true }
+elastic_lens_offical_es8 = { version = "8", optional = true }
 
-# TODO: make this optional with a version?
-elasticsearch = "7.14.0-alpha.1"
+[features]
+offical_client = []
+es_7 = []
+es_8 = []
+offical_es7 = ["elastic_lens_offical_es7", "offical_client", "es_7"]
+offical_es8 = ["elastic_lens_offical_es8", "offical_client", "es_8"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Elastic Lens
 
+[![Crates.io](https://img.shields.io/crates/v/elastic_lens.svg)](https://crates.io/crates/elastic_lens)
+[![Rust](https://github.com/benfalk/elastic_lens/workflows/CI/badge.svg)](https://github.com/benfalk/elastic_lens/actions)
+
 > An opinionated framework to work with Elasticsearch.
 
 ## About
@@ -13,6 +16,19 @@ This project is in it's infancy and is currently supporting a
 real work project.  This is what is driving it's development
 for now; however, if you have suggestions or edits please feel
 free to open an issue :+1:.
+
+## Getting Started
+
+In your `Cargo.toml` file:
+
+```toml
+# You must pick one of the currently two supported adapters
+# - "offical_es7"
+# - "offical_es8"
+elastic_lens = { version = "0.1.0", features=["offical_es7"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+```
 
 ## Functionality Tour
 

--- a/adapters/offical_es7/.gitignore
+++ b/adapters/offical_es7/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/adapters/offical_es7/Cargo.toml
+++ b/adapters/offical_es7/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "elastic_lens_offical_es7"
+version = "7.14.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/benfalk/elastic_lens"
+description = "Tag for Elasticsearch 7.x.x to be used by ElasticLens"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+elasticsearch = { version = "7.14.0-alpha.1" }

--- a/adapters/offical_es7/src/lib.rs
+++ b/adapters/offical_es7/src/lib.rs
@@ -1,0 +1,4 @@
+//! This crate is used as a simple way to track the offical
+//! Elasticsearch 7.x.x series of clients.  Unless you are
+//! using `ElasticLens` there is no reason to use this crate.
+pub use elasticsearch;

--- a/adapters/offical_es8/.gitignore
+++ b/adapters/offical_es8/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/adapters/offical_es8/Cargo.toml
+++ b/adapters/offical_es8/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "elastic_lens_offical_es8"
+version = "8.5.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/benfalk/elastic_lens"
+description = "Tag for Elasticsearch 7.x.x to be used by ElasticLens"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+elasticsearch = { version = "8.5.0-alpha.1" }

--- a/adapters/offical_es8/src/lib.rs
+++ b/adapters/offical_es8/src/lib.rs
@@ -1,0 +1,4 @@
+//! This crate is used as a simple way to track the offical
+//! Elasticsearch 8.x.x series of clients.  Unless you are
+//! using `ElasticLens` there is no reason to use this crate.
+pub use elasticsearch;

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,6 +8,7 @@
 
 mod adapter;
 mod builder;
+#[cfg(feature = "offical_client")]
 mod offical_adapter;
 mod settings;
 
@@ -22,6 +23,7 @@ use crate::{
 use serde::de::DeserializeOwned;
 
 /// The adapter which is used by default for the ClientBuilder
+#[cfg(feature = "offical_client")]
 pub type DefaultAdapter = offical_adapter::ElasticsearchAdapter;
 
 /// Result for the client where the Error is always a ClientError
@@ -49,6 +51,7 @@ pub struct Client<T: ClientAdapter> {
     settings: Settings,
 }
 
+#[cfg(feature = "offical_client")]
 impl Client<DefaultAdapter> {
     /// Create a builder which drives the creation of a client
     pub fn default_builder() -> ClientBuilder<DefaultAdapter> {

--- a/src/client/adapter.rs
+++ b/src/client/adapter.rs
@@ -42,9 +42,10 @@ pub trait ClientAdapter: private::SealedClientAdapter {
 }
 
 mod private {
-    use crate::client::offical_adapter::ElasticsearchAdapter;
-
     pub trait SealedClientAdapter: Send + Sync + Sized {}
 
+    #[cfg(feature = "offical_client")]
+    use crate::client::offical_adapter::ElasticsearchAdapter;
+    #[cfg(feature = "offical_client")]
     impl SealedClientAdapter for ElasticsearchAdapter {}
 }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -5,6 +5,7 @@ use super::*;
 pub struct ClientBuilder<T: ClientAdapter> {
     index: Option<String>,
     host: Option<String>,
+    #[cfg(feature = "es_7")]
     doc_type: Option<String>,
     credentials: Option<Credentials>,
     default_limit: Option<usize>,
@@ -30,6 +31,7 @@ impl<T: ClientAdapter> Default for ClientBuilder<T> {
         Self {
             index: None,
             host: None,
+            #[cfg(feature = "es_7")]
             doc_type: None,
             credentials: None,
             default_limit: None,
@@ -72,6 +74,7 @@ impl<T: ClientAdapter> ClientBuilder<T> {
     /// purposes.  If this is you consider getting away from that
     /// sooner than later.
     ///
+    #[cfg(feature = "es_7")]
     pub fn doc_type<S: Into<String>>(mut self, doc_type: S) -> Self {
         self.doc_type = Some(doc_type.into());
         self
@@ -158,6 +161,7 @@ impl<T: ClientAdapter> ClientBuilder<T> {
         Ok(Settings {
             host: self.host.take().unwrap(),
             index: self.index.take().unwrap(),
+            #[cfg(feature = "es_7")]
             doc_type: self.doc_type.take(),
             credentials: self.credentials.take(),
             default_limit: self.default_limit.take(),

--- a/src/client/settings.rs
+++ b/src/client/settings.rs
@@ -4,6 +4,7 @@
 pub struct Settings {
     pub(super) index: String,
     pub(super) host: String,
+    #[cfg(feature = "es_7")]
     pub(super) doc_type: Option<String>,
     pub(super) credentials: Option<Credentials>,
     pub(crate) default_limit: Option<usize>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@
     )
 )]
 
+#[cfg(all(feature = "es_7", feature = "es_8"))]
+compile_error!("feature \"es_7\" and feature \"es_8\" cannot be enabled at the same time");
+
 pub mod client;
 pub mod request;
 pub mod response;


### PR DESCRIPTION
This is all of the works needed in preperation to publish this onto `crates.io`.  In order to be able to targe the radically different versions of the offical Elasticsearch crate I have made and published shell crates that target the respective versions.