### PR TITLE
Remove Need for `Debug` and `Clone` for Search Models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2023-01-16
+
+### Removed
+
+- Requirement for `Debug` and `Clone` for types `T` in `SearchResults`
+  is no longer required in order for `Client#search` to return results.
+  Now if the type `T` **does** implement both/either trait then
+  `SearchResults` will also have that functionality.
+
 ## [0.1.1] - 2023-01-15
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = [
   "Ben Falk <benjamin.falk@yahoo.com>"
@@ -8,7 +8,7 @@ authors = [
 description = "An opinionated framework to work with Elasticsearch."
 license-file = "LICENSE.md"
 repository = "https://github.com/benfalk/elastic_lens"
-categories = ["framework"]
+categories = ["database"]
 keywords = ["elasticsearch"]
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In your `Cargo.toml` file:
 # You must pick one of the currently two supported adapters
 # - "official_es7"
 # - "official_es8"
-elastic_lens = { version = "0.1.1", features = ["official_es7"] }
+elastic_lens = { version = "0.1.2", features = ["official_es7"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 ```

--- a/examples/sample_code.rs
+++ b/examples/sample_code.rs
@@ -244,3 +244,22 @@ pub mod five_cheapest {
         Ok(client.search(&search).await?)
     }
 }
+
+pub mod without_clone_or_debug {
+    use crate::create_client::create_client;
+    use elastic_lens::{prelude::*, response::SearchResults, Error};
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    pub struct User {
+        name: String,
+    }
+
+    pub async fn top_five_users() -> Result<SearchResults<User>, Error> {
+        let client = create_client()?;
+        let mut search = Search::default();
+        search.sort(by_field("score").descending().with_missing_values_last());
+        search.set_limit(5);
+        Ok(client.search(&search).await?)
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -80,7 +80,7 @@ impl<T: ClientAdapter> Client<T> {
     /// Execute a Search
     pub async fn search<D>(&self, search: &impl SearchTrait) -> ClientResult<SearchResults<D>>
     where
-        D: DeserializeOwned + Clone + std::fmt::Debug,
+        D: DeserializeOwned,
     {
         let mut body = search.search_body();
         body.apply_defaults(&self.settings);


### PR DESCRIPTION
Requirement for `Debug` and `Clone` for types `T` in `SearchResults` is no longer required in order for `Client#search` to return results. Now if the type `T` **does** implement both/either trait then `SearchResults` will also have that functionality.