### PR TITLE
Add Mutable Search Result methods for Documents and Hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2023-01-16
+
+### Added
+
+- `hits_mut()` and `docs_mut()` mutable iterators to search results
+- `hits_take()` and `docs_take()` to extract collections from results
+- Make offical adapter clone-able so the client can also be cloned
+
 ## [0.1.2] - 2023-01-16
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = [
   "Ben Falk <benjamin.falk@yahoo.com>"

--- a/src/client/official_adapter.rs
+++ b/src/client/official_adapter.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 
 mod util;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ElasticsearchAdapter {
     es_client: Elasticsearch,
     settings: Settings,

--- a/src/response/search_results.rs
+++ b/src/response/search_results.rs
@@ -78,9 +78,41 @@ impl<T> SearchResults<T> {
         self.hits.iter()
     }
 
+    /// mutable iterator over the entire hit from your search
+    pub fn hits_mut(&mut self) -> impl Iterator<Item = &mut DocumentHit<T>> {
+        self.hits.iter_mut()
+    }
+
+    /// takes the entire document hit collection from the results
+    pub fn hits_take(&mut self) -> Vec<DocumentHit<T>> {
+        let mut hits = vec![];
+        std::mem::swap(&mut hits, &mut self.hits);
+        hits
+    }
+
+    /// extracts the documents out of the results and returns them
+    /// as a vector.  This completely drains all of the document data
+    /// from the results leaving it empty.
+    pub fn docs_take(&mut self) -> Vec<T> {
+        let capacity = self.hits.len();
+
+        self.hits
+            .drain(..)
+            .map(|h| h.doc)
+            .rfold(Vec::with_capacity(capacity), |mut docs, doc| {
+                docs.push(doc);
+                docs
+            })
+    }
+
     /// convenience iterator over the documents from your current search
     pub fn docs(&self) -> impl Iterator<Item = &T> {
         self.hits.iter().map(|d| &d.doc)
+    }
+
+    /// convenience mutable document iterator from your search
+    pub fn docs_mut(&mut self) -> impl Iterator<Item = &mut T> {
+        self.hits.iter_mut().map(|d| &mut d.doc)
     }
 
     /// Read-Only Access to the aggregations in the response


### PR DESCRIPTION
- `hits_mut()` and `docs_mut()` mutable iterators to search results
- `hits_take()` and `docs_take()` to extract collections from results
- Make offical adapter clone-able so the client can also be cloned

closes #24 