### PR TITLE
Add Support for more Scalar Value Conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.4] - 2023-01-17
+
+### Added
+
+- `Cow<'static, str>` can now be coerced to a `ScalarValue` directly.
+- `u8`, `u16`, `u32`, `i32`, `i16`, `i8` are now coerced to `ScalarValue`
+- `f32` is now coerced to `ScalarValue`
+
 ## [0.1.3] - 2023-01-16
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = [
   "Ben Falk <benjamin.falk@yahoo.com>"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In your `Cargo.toml` file:
 # You must pick one of the currently two supported adapters
 # - "official_es7"
 # - "official_es8"
-elastic_lens = { version = "0.1.2", features = ["official_es7"] }
+elastic_lens = { version = "0.1.4", features = ["official_es7"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 ```

--- a/src/request/search/scalar_value.rs
+++ b/src/request/search/scalar_value.rs
@@ -30,9 +30,57 @@ impl From<String> for ScalarValue {
     }
 }
 
+impl From<Cow<'static, str>> for ScalarValue {
+    fn from(value: Cow<'static, str>) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<f32> for ScalarValue {
+    fn from(value: f32) -> Self {
+        Self::Float(value as f64)
+    }
+}
+
 impl From<f64> for ScalarValue {
     fn from(value: f64) -> Self {
         Self::Float(value)
+    }
+}
+
+impl From<u8> for ScalarValue {
+    fn from(value: u8) -> Self {
+        Self::Integer(value as i64)
+    }
+}
+
+impl From<u16> for ScalarValue {
+    fn from(value: u16) -> Self {
+        Self::Integer(value as i64)
+    }
+}
+
+impl From<u32> for ScalarValue {
+    fn from(value: u32) -> Self {
+        Self::Integer(value as i64)
+    }
+}
+
+impl From<i32> for ScalarValue {
+    fn from(value: i32) -> Self {
+        Self::Integer(value as i64)
+    }
+}
+
+impl From<i16> for ScalarValue {
+    fn from(value: i16) -> Self {
+        Self::Integer(value as i64)
+    }
+}
+
+impl From<i8> for ScalarValue {
+    fn from(value: i8) -> Self {
+        Self::Integer(value as i64)
     }
 }
 


### PR DESCRIPTION
Upon playing with ElasticLens locally it has become apparently quite quickly that more types need to be coerced to Scalar value:

- `Cow<'static, str>` can now be coerced to a `ScalarValue` directly.
- `u8`, `u16`, `u32`, `i32`, `i16`, `i8` are now coerced to `ScalarValue`
- `f32` is now coerced to `ScalarValue`