### PR TITLE
Add `MultiResponse::to_inner(&self)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2023-01-20
+
+### Added
+
+- Support to unwrap the `MultiResponse` structure down to it's underlying
+  vector of search result payloads.
+
 ## [0.1.5] - 2023-01-20
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = [
   "Ben Falk <benjamin.falk@yahoo.com>"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In your `Cargo.toml` file:
 # You must pick one of the currently two supported adapters
 # - "official_es7"
 # - "official_es8"
-elastic_lens = { version = "0.1.5", features = ["official_es7"] }
+elastic_lens = { version = "0.1.6", features = ["official_es7"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 ```

--- a/src/response/multi_results.rs
+++ b/src/response/multi_results.rs
@@ -9,6 +9,17 @@ pub struct MultiResponse<T> {
     responses: Vec<SearchResults<T>>,
 }
 
+impl<T> MultiResponse<T> {
+    /// Retruns the actual data `MultiResponse` was working
+    /// with; which is a vector of the search results.  In
+    /// some cases when you want to perform more ownership
+    /// based access on the data this is probably the best
+    /// way to get at it.
+    pub fn to_inner(self) -> Vec<SearchResults<T>> {
+        self.responses
+    }
+}
+
 impl<T> Index<usize> for MultiResponse<T> {
     type Output = SearchResults<T>;
 


### PR DESCRIPTION
Upon working with the multi-response it has become quite apparent that there are ownership needs for the underlying data that are needed.  Instead of trying to mimic all of the features of the vector that contains the data I have elected to simply allow users to unwrap the `MultiResponse` down to the actual data with `#to_inner`.