### PR TITLE
Fix `empty bool` Malformed Query Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.7] - 2023-01-2021
+
+### Fixed
+
+- Empty `bool` query building bug is fixed.  When attempting to build
+  a search if you apply an empty criteria set, such as an `AllMatch`
+  it would generate a malformed query where the `bool` node had an
+  empty filter.  Now criterion are checked before being applied to a
+  search to prevent this going forward.
+
 ## [0.1.6] - 2023-01-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = [
   "Ben Falk <benjamin.falk@yahoo.com>"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In your `Cargo.toml` file:
 # You must pick one of the currently two supported adapters
 # - "official_es7"
 # - "official_es8"
-elastic_lens = { version = "0.1.6", features = ["official_es7"] }
+elastic_lens = { version = "0.1.7", features = ["official_es7"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 ```

--- a/examples/sample_code.rs
+++ b/examples/sample_code.rs
@@ -252,6 +252,7 @@ pub mod without_clone_or_debug {
 
     #[derive(Deserialize)]
     pub struct User {
+        #[allow(dead_code)]
         name: String,
     }
 

--- a/src/request/search/criterion.rs
+++ b/src/request/search/criterion.rs
@@ -52,6 +52,17 @@ pub enum Criterion {
     AllMatch(AllMatch),
 }
 
+impl Criterion {
+    pub(crate) fn is_usable(&self) -> bool {
+        match self {
+            Self::AllMatch(all) => all.has_data(),
+            Self::NotAll(not_all) => not_all.has_data(),
+            Self::AnyMatch(any) => any.has_data(),
+            _ => true,
+        }
+    }
+}
+
 impl Serialize for Criterion {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/request/search/criterion/all_match.rs
+++ b/src/request/search/criterion/all_match.rs
@@ -15,6 +15,12 @@ pub struct AllMatch {
     negative_criteria: Vec<Criterion>,
 }
 
+impl AllMatch {
+    pub(crate) fn has_data(&self) -> bool {
+        !(self.negative_criteria.is_empty() && self.positive_criteria.is_empty())
+    }
+}
+
 /// Selects if all criteria given select
 pub fn if_all_match<F>(mut func: F) -> AllMatch
 where

--- a/src/request/search/criterion/any_match.rs
+++ b/src/request/search/criterion/any_match.rs
@@ -31,6 +31,10 @@ impl AnyMatch {
     pub fn add<C: Into<Criterion>>(&mut self, criterion: C) {
         self.criteria.push(criterion.into());
     }
+
+    pub(crate) fn has_data(&self) -> bool {
+        !self.criteria.is_empty()
+    }
 }
 
 impl Serialize for AnyMatch {

--- a/src/request/search/criterion/builder_trait.rs
+++ b/src/request/search/criterion/builder_trait.rs
@@ -23,6 +23,9 @@ pub trait CriteriaBuilder: Sized {
     /// Having the provided condition
     fn with<SC: Into<SearchCondition>>(&mut self, condition: SC) {
         let condition = condition.into();
-        <Self::Bucket as BucketPlacer>::push(self, condition.criterion, condition.tag);
+
+        if condition.criterion.is_usable() {
+            <Self::Bucket as BucketPlacer>::push(self, condition.criterion, condition.tag);
+        }
     }
 }

--- a/src/request/search/criterion/not_all.rs
+++ b/src/request/search/criterion/not_all.rs
@@ -11,6 +11,12 @@ pub struct NotAll {
 }
 
 impl NotAll {
+    pub(crate) fn has_data(&self) -> bool {
+        !self.criteria.is_empty()
+    }
+}
+
+impl NotAll {
     /// Consumes a criterion and negates it
     pub fn single<C: Into<Criterion>>(criterion: C) -> Self {
         Self {

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -638,3 +638,36 @@ fn building_a_search_with_a_script_sort_and_params() {
         })
     );
 }
+
+#[test]
+fn building_a_search_with_an_empty_all_match() {
+    use elastic_lens::request::search::AllMatch;
+
+    let mut search = Search::default();
+    let all = AllMatch::default();
+    search.with(all);
+
+    assert_eq!(search_to_json(search), json!({}));
+}
+
+#[test]
+fn building_a_search_with_an_empty_any_match() {
+    use elastic_lens::request::search::AnyMatch;
+
+    let mut search = Search::default();
+    let any = AnyMatch::default();
+    search.with(any);
+
+    assert_eq!(search_to_json(search), json!({}));
+}
+
+#[test]
+fn building_a_search_with_an_empty_not_all_match() {
+    use elastic_lens::request::search::NotAll;
+
+    let mut search = Search::default();
+    let not_all = NotAll::default();
+    search.with(not_all);
+
+    assert_eq!(search_to_json(search), json!({}));
+}


### PR DESCRIPTION
Empty `bool` query building bug is fixed.  When attempting to build a search if you apply an empty criteria set, such as an `AllMatch` it would generate a malformed query where the `bool` node had an empty filter.  Now criterion are checked before being applied to a search to prevent this going forward.