### PR TITLE
Add `unwrap_as` and `borrow_as` to `AggResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.7] - 2023-01-2021
+## [0.1.8] - 2023-01-24
+
+### Added
+
+- Ergonomic methods to `AggResult` that allow you to directly get at
+  the data the enum is wrapping.  Prior to this change you had to work
+  directly from the `AggResultCollection`; which may not always be the
+  case if you're attempting to pass individual results around to be
+  processedd by the the code that created the request for them w/o
+  passing the entire collection.
+
+## [0.1.7] - 2023-01-21
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = [
   "Ben Falk <benjamin.falk@yahoo.com>"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In your `Cargo.toml` file:
 # You must pick one of the currently two supported adapters
 # - "official_es7"
 # - "official_es8"
-elastic_lens = { version = "0.1.7", features = ["official_es7"] }
+elastic_lens = { version = "0.1.8", features = ["official_es7"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 ```

--- a/src/response/search_results/agg_result.rs
+++ b/src/response/search_results/agg_result.rs
@@ -35,6 +35,21 @@ impl AggResult {
             Self::Filtered(agg) => agg.str_identifier(),
         }
     }
+
+    /// Each AggResult wraps a specific structured data type.
+    /// Use this to unwrap the underlying structure.  This
+    /// only works if you have ownership of the data; if you
+    /// don't you may want to look at `borrow_as` instead.
+    pub fn unwrap_as<T: AggResultData>(self) -> Result<T, AggAccessError> {
+        T::unwrap_inner(self)
+    }
+
+    /// Attempts to borrow a reference to the underlying data
+    /// structure of the `AggResult`.  This and `unwrap_inner`
+    /// are the only two ways to get at the data for use.
+    pub fn borrow_as<T: AggResultData>(&self) -> Result<&T, AggAccessError> {
+        T::borrow_agg_result(self)
+    }
 }
 
 /// Sanity Tag to ensure every aggregation

--- a/src/response/search_results/agg_result/collection.rs
+++ b/src/response/search_results/agg_result/collection.rs
@@ -40,12 +40,10 @@ impl AggResultCollection {
     /// Note this doesn't do any actual downcast but instead
     /// uses enum matching.
     pub fn get<T: AggResultData>(&self, name: &str) -> Result<&T, AggAccessError> {
-        let agg = self
-            .data
+        self.data
             .get(name)
-            .ok_or_else(|| AggAccessError::AggNotFound(name.to_owned()))?;
-
-        T::borrow_agg_result(agg)
+            .ok_or_else(|| AggAccessError::AggNotFound(name.to_owned()))?
+            .borrow_as()
     }
 
     /// Retrieves the aggregation by it's name and
@@ -57,12 +55,10 @@ impl AggResultCollection {
     /// Note this doesn't do any actual downcast but instead
     /// uses enum matching.
     pub fn take<T: AggResultData>(&mut self, name: &str) -> Result<T, AggAccessError> {
-        let agg = self
-            .data
+        self.data
             .remove(name)
-            .ok_or_else(|| AggAccessError::AggNotFound(name.to_owned()))?;
-
-        T::unwrap_inner(agg)
+            .ok_or_else(|| AggAccessError::AggNotFound(name.to_owned()))?
+            .unwrap_as()
     }
 }
 


### PR DESCRIPTION
Ergonomic methods to `AggResult` that allow you to directly get at the data the enum is wrapping.  Prior to this change you had to work directly from the `AggResultCollection`; which may not always be the case if you're attempting to pass individual results around to be processedd by the the code that created the request for them w/o passing the entire collection.