### PR TITLE
🐛 Fix Stats Aggregation Representation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "elastic_lens"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2021"
-authors = [
-  "Ben Falk <benjamin.falk@yahoo.com>"
-]
+authors = ["Ben Falk <benjamin.falk@yahoo.com>"]
 description = "An opinionated framework to work with Elasticsearch."
 license-file = "LICENSE.md"
 repository = "https://github.com/benfalk/elastic_lens"

--- a/src/response/search_results/agg_result/stats_result.rs
+++ b/src/response/search_results/agg_result/stats_result.rs
@@ -9,13 +9,13 @@ pub struct Stats {
     pub count: usize,
 
     /// the minimum value found
-    pub min: f64,
+    pub min: Option<f64>,
 
     /// the maximum value found
-    pub max: f64,
+    pub max: Option<f64>,
 
     /// the average value found
-    pub avg: f64,
+    pub avg: Option<f64>,
 
     /// the sum total of all values
     pub sum: f64,


### PR DESCRIPTION
Stat aggregations coming back from Elasticsearch can contain `null` values for the `min`, `max`, and `avg` portions of the search.  This corrects that to prevent deserialization errors when fetching aggregations which have no results counted by such an aggregation.