### PR TITLE
Expose Field's Name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Ben Falk <benjamin.falk@yahoo.com>"]
 description = "An opinionated framework to work with Elasticsearch."

--- a/src/request/search/field.rs
+++ b/src/request/search/field.rs
@@ -37,6 +37,15 @@ impl Field {
             name: Cow::Borrowed(name),
         }
     }
+
+    /// Field Name
+    ///
+    /// Returns the string slice data representation of the
+    /// Elasticsearch field name.
+    ///
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
 }
 
 impl Serialize for Field {


### PR DESCRIPTION
For self inspection sometimes it is useful to be able to get
the string representation of the field.  This adds that interface
to the Field.