### PR TITLE
🔮 Exploratory Features for `AggResultCollection`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Ben Falk <benjamin.falk@yahoo.com>"]
 description = "An opinionated framework to work with Elasticsearch."

--- a/src/response/search_results/agg_result/collection.rs
+++ b/src/response/search_results/agg_result/collection.rs
@@ -60,6 +60,27 @@ impl AggResultCollection {
             .ok_or_else(|| AggAccessError::AggNotFound(name.to_owned()))?
             .unwrap_as()
     }
+
+    /// Allows for iteration over every key and [AggResult].
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &AggResult)> {
+        self.data.iter()
+    }
+
+    /// Provides an iterator over each key along with a mutable
+    /// reference to the key's [AggResult].
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&String, &mut AggResult)> {
+        self.data.iter_mut()
+    }
+
+    /// Determines if the collection has a key stored
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.data.contains_key(key)
+    }
+
+    /// Optimized iterator that returns the keys in sorted order
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.data.keys()
+    }
 }
 
 impl<'de> Deserialize<'de> for AggResultCollection {


### PR DESCRIPTION
This introduces some features which allow users of the library to
walk the aggregation results without needing to know the exact
structure ahead of time.  This allows for more generic processing
of aggregations.