### PR TITLE
🔬 Add Debug to Aggregate Result Containers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Ben Falk <benjamin.falk@yahoo.com>"]
 description = "An opinionated framework to work with Elasticsearch."

--- a/src/response/search_results/agg_result/filter_result.rs
+++ b/src/response/search_results/agg_result/filter_result.rs
@@ -2,7 +2,7 @@ use super::*;
 use serde::Deserialize;
 
 /// Results for a filtered aggregation
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct Filtered {
     /// number of documents that matched the filter
     #[serde(rename = "doc_count")]

--- a/src/response/search_results/agg_result/stats_result.rs
+++ b/src/response/search_results/agg_result/stats_result.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 
 /// Thes are numerical stats collected for a numeric field
 /// or calculation
-#[derive(Debug, Clone, Deserialize, Copy)]
+#[derive(Debug, Clone, Deserialize, Copy, Default)]
 pub struct Stats {
     /// the number of items counted for stats
     pub count: usize,

--- a/src/response/search_results/agg_result/terms_result.rs
+++ b/src/response/search_results/agg_result/terms_result.rs
@@ -8,7 +8,7 @@ pub type StringTerms = TermResults<String>;
 pub type NumericTerms = TermResults<i64>;
 
 /// Term Aggregation Results from Elasticsearch
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Default)]
 pub struct TermResults<T> {
     /// unique term counts, this is not guaranteed
     /// to be all values, it will only be the top


### PR DESCRIPTION
Being able to build these is a bit of a pain because all of the
fields must be provided when only one may be need and the remaining
defaults are fine.