### PR TITLE
🐛 Fix Empty Aggregation Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_lens"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 authors = ["Ben Falk <benjamin.falk@yahoo.com>"]
 description = "An opinionated framework to work with Elasticsearch."

--- a/tests/search_tests.rs
+++ b/tests/search_tests.rs
@@ -671,3 +671,22 @@ fn building_a_search_with_an_empty_not_all_match() {
 
     assert_eq!(search_to_json(search), json!({}));
 }
+
+#[test]
+fn building_an_empty_filter_aggregate() {
+    let mut search = Search::default();
+    // do nothing to the filter
+    search.create_aggregation("test").filtered_by(|_| ());
+    assert_eq!(
+        search_to_json(search),
+        json!({
+            "aggs": {
+                "test": {
+                    "filter": {
+                        "bool": {}
+                    }
+                }
+            }
+        })
+    );
+}


### PR DESCRIPTION
This addresses an issue where if a filter aggregation has no criteria
to filter by it was producing invalid SQL syntax.  This checks for that
condition and ensures it produces valid syntax for this scenario.